### PR TITLE
Expand reference detection, tighten name normalization, and unify number-style rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ zuke convert input.md -o output.law.txt --to lawtext
 # Lawtextコマンド（ショートカット）
 zuke lawtext input.md -o output.law.txt
 
+# 番号表記（既定: kanji）
+zuke convert input.md -o output.xml --to xml --number-style kanji
+zuke convert input.md -o output.xml --to xml --number-style arabic
+
 # diff
 zuke diff old.md new.md --view unified
 zuke diff old.md new.md --view terminal
@@ -96,6 +100,13 @@ zuke diff old.md new.md --view html -o diff.html
 ## Lawtext出力
 
 Lawtext出力後、未解決の参照マクロ・参照ラベル・絵文字（🍣）が残っているとエラー（LMD064 / LMD065）になります。
+
+## --number-style
+
+- 既定値は `kanji` です。
+- `--number-style kanji` の場合、条・章・節・号・参照表現は漢数字で出力されます（例: `第一条`）。
+- `--number-style arabic` の場合、条・章・節・号・参照表現は算用数字で出力されます（例: `第1条`）。
+- この挙動は法令XML出力とLawtext出力で一貫します。
 
 ## diff
 

--- a/src/Zuke.Cli/Commands/ConvertCommand.cs
+++ b/src/Zuke.Cli/Commands/ConvertCommand.cs
@@ -35,7 +35,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         if (settings.To == "lawtext")
         {
             var renderer = new LawtextRenderer();
-            var lawtext = renderer.Render(result.Document, LawtextRenderOptions.Default);
+            var lawtext = renderer.Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
             var renderDiags = LawtextRenderer.ValidateRenderedText(lawtext);
             reporter.ReportDiagnostics(renderDiags);
             if (renderDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
@@ -45,7 +45,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
             return 0;
         }
 
-        var doc = new LawXmlRenderer().Render(result.Document.Document);
+        var doc = new LawXmlRenderer().Render(result.Document.Document, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
         if (!settings.SkipValidation)
         {
             var xsd = settings.Xsd ?? ZukeXsdProvider.ResolveDefaultPath();

--- a/src/Zuke.Core/Compilation/LawMarkdownCompiler.cs
+++ b/src/Zuke.Core/Compilation/LawMarkdownCompiler.cs
@@ -16,16 +16,57 @@ public sealed class LawMarkdownCompiler
         var diags = new List<DiagnosticMessage>(model.Diagnostics);
         diags.AddRange(FrontMatterParser.ValidateRequired(fm, filePath));
         diags.AddRange(new LawStructureValidator().Validate(model));
-        foreach (var a in model.DirectArticles)
-            foreach (var p in a.Paragraphs)
-                diags.AddRange(ManualReferenceDetector.Detect(p.SentenceText, p.Location ?? new(filePath,1,1), options.Strict));
+        foreach (var article in EnumerateArticles(model))
+        {
+            foreach (var paragraph in article.Paragraphs)
+            {
+                diags.AddRange(ManualReferenceDetector.Detect(paragraph.SentenceText, paragraph.Location ?? article.Location ?? new(filePath, 1, 1), options.Strict));
+                foreach (var item in paragraph.Items)
+                {
+                    DetectItemRecursive(item, item.Location ?? paragraph.Location ?? article.Location ?? new(filePath, 1, 1), options.Strict, diags);
+                }
+            }
+        }
 
         model = new NumberingService().Apply(model, options.ArabicNumbers);
         var (table, refDiags) = new ReferenceTableBuilder().Build(model);
         diags.AddRange(refDiags);
-        var (resolved, resolveDiags) = new ReferenceResolver().Resolve(model, table);
+        var (resolved, resolveDiags) = new ReferenceResolver().Resolve(model, table, options.ArabicNumbers);
         diags.AddRange(resolveDiags);
         var compiled = new CompiledLawDocument(resolved, table, diags);
         return new CompileResult(compiled, diags);
+    }
+
+    private static IEnumerable<ArticleNode> EnumerateArticles(LawDocumentModel model)
+    {
+        foreach (var article in model.DirectArticles)
+        {
+            yield return article;
+        }
+
+        foreach (var chapter in model.Chapters)
+        {
+            foreach (var article in chapter.Articles)
+            {
+                yield return article;
+            }
+
+            foreach (var section in chapter.Sections)
+            {
+                foreach (var article in section.Articles)
+                {
+                    yield return article;
+                }
+            }
+        }
+    }
+
+    private static void DetectItemRecursive(ItemNode item, SourceLocation location, bool strict, List<DiagnosticMessage> diags)
+    {
+        diags.AddRange(ManualReferenceDetector.Detect(item.SentenceText, location, strict));
+        foreach (var child in item.Children)
+        {
+            DetectItemRecursive(child, child.Location ?? location, strict, diags);
+        }
     }
 }

--- a/src/Zuke.Core/Numbering/JapaneseNumberFormatter.cs
+++ b/src/Zuke.Core/Numbering/JapaneseNumberFormatter.cs
@@ -3,15 +3,31 @@ namespace Zuke.Core.Numbering;
 public static class JapaneseNumberFormatter
 {
     public static string ToArticle(int n, bool arabic)
-        => arabic ? $"第{n}条" : $"第{ToKanjiNumber(n)}条";
+        => $"第{FormatNumber(n, arabic)}条";
+
+    public static string ToChapter(int n, bool arabic)
+        => $"第{FormatNumber(n, arabic)}章";
+
+    public static string ToSection(int n, bool arabic)
+        => $"第{FormatNumber(n, arabic)}節";
+
+    public static string ToParagraphReference(int n, bool arabic)
+        => $"第{FormatNumber(n, arabic)}項";
+
+    public static string ToItemReference(int n, bool arabic)
+        => $"第{FormatNumber(n, arabic)}号";
+
+    public static string ToItemTitle(int n, bool arabic)
+        => FormatNumber(n, arabic);
 
     public static string ToParagraphNum(int n)
         => n == 1 ? "" : ToFullWidth(n);
 
-    private static string ToKanjiNumber(int n)
+    public static string ToKanjiNumber(int n)
     {
         if (n <= 0) return "零";
-        if (n <= 10)
+
+        if (n < 10)
         {
             return n switch
             {
@@ -24,23 +40,38 @@ public static class JapaneseNumberFormatter
                 7 => "七",
                 8 => "八",
                 9 => "九",
-                10 => "十",
                 _ => n.ToString()
             };
         }
 
-        if (n < 20)
+        if (n == 10) return "十";
+
+        static string Under100(int value)
         {
-            return "十" + ToKanjiNumber(n % 10);
+            if (value < 10) return ToKanjiNumber(value);
+            if (value == 10) return "十";
+            var tens = value / 10;
+            var ones = value % 10;
+            var tensPart = tens == 1 ? "十" : $"{ToKanjiNumber(tens)}十";
+            return ones == 0 ? tensPart : $"{tensPart}{ToKanjiNumber(ones)}";
         }
 
-        if (n % 10 == 0)
+        static string Under10000(int value)
         {
-            return ToKanjiNumber(n / 10) + "十";
+            var thousands = value / 1000;
+            var hundreds = (value % 1000) / 100;
+            var under100 = value % 100;
+            var result = string.Empty;
+            if (thousands > 0) result += (thousands == 1 ? string.Empty : ToKanjiNumber(thousands)) + "千";
+            if (hundreds > 0) result += (hundreds == 1 ? string.Empty : ToKanjiNumber(hundreds)) + "百";
+            if (under100 > 0) result += Under100(under100);
+            return result;
         }
 
-        return ToKanjiNumber(n / 10) + "十" + ToKanjiNumber(n % 10);
+        return Under10000(n);
     }
+
+    private static string FormatNumber(int n, bool arabic) => arabic ? n.ToString() : ToKanjiNumber(n);
 
     private static string ToFullWidth(int n) => n.ToString()
         .Replace("0", "０", StringComparison.Ordinal)

--- a/src/Zuke.Core/Parsing/ManualReferenceDetector.cs
+++ b/src/Zuke.Core/Parsing/ManualReferenceDetector.cs
@@ -5,13 +5,24 @@ namespace Zuke.Core.Parsing;
 
 public static class ManualReferenceDetector
 {
-    private static readonly Regex R = new(@"(第\d+条(第\d+項)?|前条|前項|前号)", RegexOptions.Compiled);
+    private static readonly Regex NumericReferenceRegex = new(
+        @"(第(?:\d+|[一二三四五六七八九十百千]+)条(?:第(?:\d+|[一二三四五六七八九十百千]+)項)?|第(?:\d+|[一二三四五六七八九十百千]+)項|第(?:\d+|[一二三四五六七八九十百千]+)号)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex RelativeReferenceRegex = new(
+        @"(前条|前項|前号|次条|次項|次号|同条|同項|同号)",
+        RegexOptions.Compiled);
 
     public static IEnumerable<DiagnosticMessage> Detect(string text, SourceLocation loc, bool strict)
     {
-        if (R.IsMatch(text))
+        if (NumericReferenceRegex.IsMatch(text))
         {
             yield return new(strict ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning, "LMD020", "手書きの番号参照があります。", loc, Array.Empty<SourceLocation>());
+        }
+
+        if (RelativeReferenceRegex.IsMatch(text))
+        {
+            yield return new(strict ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning, "LMD028", "手書きの相対参照があります。", loc, Array.Empty<SourceLocation>());
         }
     }
 }

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -81,7 +81,7 @@ public sealed class MarkdownLawParser
                     paragraphs.Add(new ParagraphNode(1, null, null, string.Empty, new(filePath, articleStart, 1), []));
                 }
 
-                var article = new ArticleNode(articleNo, articleRefName, caption, $"第{JapaneseNumberFormatter.ToArticle(articleNo, false).Replace("第", "", StringComparison.Ordinal)}", new(filePath, articleStart, 1), paragraphs);
+                var article = new ArticleNode(articleNo, articleRefName, caption, JapaneseNumberFormatter.ToArticle(articleNo, false), new(filePath, articleStart, 1), paragraphs);
                 if (currentSection is not null) secArticles.Add(article);
                 else if (currentChapter is not null) chArticles.Add(article);
                 else direct.Add(article);
@@ -215,7 +215,7 @@ public sealed class MarkdownLawParser
                 {
                     if (currentItems.Count == 0)
                     {
-                        currentItems.Add(new ItemNode(++itemNo, null, ToItemKanji(itemNo), string.Empty, new(filePath, lineNo, 1), []));
+                        currentItems.Add(new ItemNode(++itemNo, null, JapaneseNumberFormatter.ToItemTitle(itemNo, false), string.Empty, new(filePath, lineNo, 1), []));
                     }
 
                     var parent = currentItems[^1];
@@ -226,7 +226,7 @@ public sealed class MarkdownLawParser
                 else
                 {
                     var nextNo = ++itemNo;
-                    currentItems.Add(new ItemNode(nextNo, itemRefName, string.IsNullOrWhiteSpace(itemTitle) ? ToItemKanji(nextNo) : itemTitle, itemText, new(filePath, lineNo, 1), []));
+                    currentItems.Add(new ItemNode(nextNo, itemRefName, string.IsNullOrWhiteSpace(itemTitle) ? JapaneseNumberFormatter.ToItemTitle(nextNo, false) : itemTitle, itemText, new(filePath, lineNo, 1), []));
                 }
 
                 continue;
@@ -317,18 +317,4 @@ public sealed class MarkdownLawParser
 
         return false;
     }
-
-    private static string ToItemKanji(int n) => n switch
-    {
-        1 => "一",
-        2 => "二",
-        3 => "三",
-        4 => "四",
-        5 => "五",
-        6 => "六",
-        7 => "七",
-        8 => "八",
-        9 => "九",
-        _ => n.ToString()
-    };
 }

--- a/src/Zuke.Core/References/ReferenceNameNormalizer.cs
+++ b/src/Zuke.Core/References/ReferenceNameNormalizer.cs
@@ -10,7 +10,10 @@ public static class ReferenceNameNormalizer
         if (string.IsNullOrWhiteSpace(raw)) return false;
 
         var folded = ToAscii(raw.Trim().Normalize(NormalizationForm.FormKC));
-        if (folded.IndexOfAny(['{', '}', '|', '[', ']', '<', '>', '"']) >= 0) return false;
+        if (folded.IndexOfAny([' ', '\u3000', '\r', '\n', ':', '|', '{', '}', '[', ']', '(', ')', '：', '（', '）']) >= 0)
+        {
+            return false;
+        }
 
         normalized = folded.ToLowerInvariant();
         return normalized.Length > 0;

--- a/src/Zuke.Core/References/ReferenceResolver.cs
+++ b/src/Zuke.Core/References/ReferenceResolver.cs
@@ -1,11 +1,12 @@
 using Zuke.Core.Model;
+using Zuke.Core.Numbering;
 using Zuke.Core.Parsing;
 
 namespace Zuke.Core.References;
 
 public sealed class ReferenceResolver
 {
-    public (LawDocumentModel, IReadOnlyList<DiagnosticMessage>) Resolve(LawDocumentModel model, IReadOnlyDictionary<string, ReferenceDefinition> table)
+    public (LawDocumentModel, IReadOnlyList<DiagnosticMessage>) Resolve(LawDocumentModel model, IReadOnlyDictionary<string, ReferenceDefinition> table, bool arabicNumbers = false)
     {
         var diags = new List<DiagnosticMessage>();
 
@@ -14,37 +15,37 @@ public sealed class ReferenceResolver
             {
                 Sections = ch.Sections.Select(sec => sec with
                 {
-                    Articles = sec.Articles.Select(a => ResolveArticle(a, table, diags)).ToList()
+                    Articles = sec.Articles.Select(a => ResolveArticle(a, table, diags, arabicNumbers)).ToList()
                 }).ToList(),
-                Articles = ch.Articles.Select(a => ResolveArticle(a, table, diags)).ToList()
+                Articles = ch.Articles.Select(a => ResolveArticle(a, table, diags, arabicNumbers)).ToList()
             })
             .ToList();
 
-        var direct = model.DirectArticles.Select(a => ResolveArticle(a, table, diags)).ToList();
+        var direct = model.DirectArticles.Select(a => ResolveArticle(a, table, diags, arabicNumbers)).ToList();
 
         return (model with { Chapters = chapters, DirectArticles = direct }, diags);
     }
 
-    private static ArticleNode ResolveArticle(ArticleNode article, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags)
+    private static ArticleNode ResolveArticle(ArticleNode article, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags, bool arabicNumbers)
     {
         var paragraphs = article.Paragraphs.Select(p =>
         {
-            var items = p.Items.Select(i => ResolveItem(article, p, i, table, diags)).ToList();
-            var sentence = ResolveText(article, p, null, p.SentenceText, table, diags, p.Location);
+            var items = p.Items.Select(i => ResolveItem(article, p, i, table, diags, arabicNumbers)).ToList();
+            var sentence = ResolveText(article, p, null, p.SentenceText, table, diags, p.Location, arabicNumbers);
             return p with { SentenceText = sentence, Items = items };
         }).ToList();
 
         return article with { Paragraphs = paragraphs };
     }
 
-    private static ItemNode ResolveItem(ArticleNode article, ParagraphNode paragraph, ItemNode item, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags)
+    private static ItemNode ResolveItem(ArticleNode article, ParagraphNode paragraph, ItemNode item, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags, bool arabicNumbers)
     {
-        var text = ResolveText(article, paragraph, item, item.SentenceText, table, diags, item.Location);
-        var children = item.Children.Select(c => c with { SentenceText = ResolveText(article, paragraph, c, c.SentenceText, table, diags, c.Location) }).ToList();
+        var text = ResolveText(article, paragraph, item, item.SentenceText, table, diags, item.Location, arabicNumbers);
+        var children = item.Children.Select(c => c with { SentenceText = ResolveText(article, paragraph, c, c.SentenceText, table, diags, c.Location, arabicNumbers) }).ToList();
         return item with { SentenceText = text, Children = children };
     }
 
-    private static string ResolveText(ArticleNode currentArticle, ParagraphNode currentParagraph, ItemNode? currentItem, string text, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags, SourceLocation? loc)
+    private static string ResolveText(ArticleNode currentArticle, ParagraphNode currentParagraph, ItemNode? currentItem, string text, IReadOnlyDictionary<string, ReferenceDefinition> table, List<DiagnosticMessage> diags, SourceLocation? loc, bool arabicNumbers)
     {
         return ReferenceParser.RefRegex.Replace(text, m =>
         {
@@ -90,39 +91,24 @@ public sealed class ReferenceResolver
 
             return option switch
             {
-                ReferenceOption.ArticleOnly => $"第{ToKanji(target.ArticleNumber)}条",
-                ReferenceOption.Full => RenderFull(target),
-                ReferenceOption.Auto => RenderAuto(target),
-                _ => RenderAuto(target)
+                ReferenceOption.ArticleOnly => JapaneseNumberFormatter.ToArticle(target.ArticleNumber, arabicNumbers),
+                ReferenceOption.Full => RenderFull(target, arabicNumbers),
+                ReferenceOption.Auto => RenderAuto(target, arabicNumbers),
+                _ => RenderAuto(target, arabicNumbers)
             };
         });
     }
 
-    private static string RenderAuto(ReferenceDefinition target)
+    private static string RenderAuto(ReferenceDefinition target, bool arabicNumbers)
     {
         return target.Kind switch
         {
-            LawElementKind.Article => $"第{ToKanji(target.ArticleNumber)}条",
-            LawElementKind.Paragraph => $"第{ToKanji(target.ArticleNumber)}条第{ToKanji(target.ParagraphNumber ?? 1)}項",
-            LawElementKind.Item => $"第{ToKanji(target.ArticleNumber)}条第{ToKanji(target.ParagraphNumber ?? 1)}項第{ToKanji(target.ItemNumber ?? 1)}号",
+            LawElementKind.Article => JapaneseNumberFormatter.ToArticle(target.ArticleNumber, arabicNumbers),
+            LawElementKind.Paragraph => $"{JapaneseNumberFormatter.ToArticle(target.ArticleNumber, arabicNumbers)}{JapaneseNumberFormatter.ToParagraphReference(target.ParagraphNumber ?? 1, arabicNumbers)}",
+            LawElementKind.Item => $"{JapaneseNumberFormatter.ToArticle(target.ArticleNumber, arabicNumbers)}{JapaneseNumberFormatter.ToParagraphReference(target.ParagraphNumber ?? 1, arabicNumbers)}{JapaneseNumberFormatter.ToItemReference(target.ItemNumber ?? 1, arabicNumbers)}",
             _ => target.RawName
         };
     }
 
-    private static string RenderFull(ReferenceDefinition target) => RenderAuto(target);
-
-    private static string ToKanji(int n) => n switch
-    {
-        1 => "一",
-        2 => "二",
-        3 => "三",
-        4 => "四",
-        5 => "五",
-        6 => "六",
-        7 => "七",
-        8 => "八",
-        9 => "九",
-        10 => "十",
-        _ => n.ToString()
-    };
+    private static string RenderFull(ReferenceDefinition target, bool arabicNumbers) => RenderAuto(target, arabicNumbers);
 }

--- a/src/Zuke.Core/Rendering/LawXmlRenderOptions.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderOptions.cs
@@ -1,1 +1,8 @@
-namespace Zuke.Core.Rendering; public sealed record LawXmlRenderOptions;
+namespace Zuke.Core.Rendering;
+
+public sealed record LawXmlRenderOptions
+{
+    public static LawXmlRenderOptions Default { get; } = new();
+
+    public bool ArabicNumbers { get; init; }
+}

--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -6,8 +6,9 @@ namespace Zuke.Core.Rendering;
 
 public sealed class LawXmlRenderer
 {
-    public XDocument Render(LawDocumentModel model)
+    public XDocument Render(LawDocumentModel model, LawXmlRenderOptions? options = null)
     {
+        options ??= LawXmlRenderOptions.Default;
         var root = new XElement("Law",
             new XAttribute("Era", model.Metadata.Era),
             new XAttribute("Year", model.Metadata.Year),
@@ -15,32 +16,32 @@ public sealed class LawXmlRenderer
             new XAttribute("LawType", model.Metadata.LawType),
             new XAttribute("Lang", model.Metadata.Lang),
             new XElement("LawNum", model.Metadata.LawNum),
-            new XElement("LawBody", new XElement("LawTitle", model.Metadata.LawTitle), new XElement("MainProvision", RenderMain(model))));
+            new XElement("LawBody", new XElement("LawTitle", model.Metadata.LawTitle), new XElement("MainProvision", RenderMain(model, options))));
         return new XDocument(root);
     }
 
-    private static IEnumerable<XElement> RenderMain(LawDocumentModel model)
+    private static IEnumerable<XElement> RenderMain(LawDocumentModel model, LawXmlRenderOptions options)
     {
         foreach (var c in model.Chapters)
         {
-            yield return new XElement("Chapter", new XAttribute("Num", c.Number), new XElement("ChapterTitle", $"第{ToKanji(c.Number)}章　{c.Title}"), c.Sections.Select(RenderSection), c.Articles.Select(RenderArticle));
+            yield return new XElement("Chapter", new XAttribute("Num", c.Number), new XElement("ChapterTitle", $"{JapaneseNumberFormatter.ToChapter(c.Number, options.ArabicNumbers)}　{c.Title}"), c.Sections.Select(s => RenderSection(s, options)), c.Articles.Select(a => RenderArticle(a, options)));
         }
 
         foreach (var a in model.DirectArticles)
         {
-            yield return RenderArticle(a);
+            yield return RenderArticle(a, options);
         }
     }
 
-    private static XElement RenderSection(SectionNode s)
-        => new("Section", new XAttribute("Num", s.Number), new XElement("SectionTitle", $"第{ToKanji(s.Number)}節　{s.Title}"), s.Articles.Select(RenderArticle));
+    private static XElement RenderSection(SectionNode s, LawXmlRenderOptions options)
+        => new("Section", new XAttribute("Num", s.Number), new XElement("SectionTitle", $"{JapaneseNumberFormatter.ToSection(s.Number, options.ArabicNumbers)}　{s.Title}"), s.Articles.Select(a => RenderArticle(a, options)));
 
-    private static XElement RenderArticle(ArticleNode a)
+    private static XElement RenderArticle(ArticleNode a, LawXmlRenderOptions options)
     {
         var elements = new List<object>
         {
             new XAttribute("Num", a.Number),
-            new XElement("ArticleTitle", $"第{ToKanji(a.Number)}条")
+            new XElement("ArticleTitle", JapaneseNumberFormatter.ToArticle(a.Number, options.ArabicNumbers))
         };
 
         if (!string.IsNullOrWhiteSpace(a.Caption))
@@ -52,19 +53,19 @@ public sealed class LawXmlRenderer
             }
         }
 
-        elements.AddRange(a.Paragraphs.Select(RenderParagraph));
+        elements.AddRange(a.Paragraphs.Select(p => RenderParagraph(p, options)));
         return new XElement("Article", elements.ToArray());
     }
 
-    private static XElement RenderParagraph(ParagraphNode p)
+    private static XElement RenderParagraph(ParagraphNode p, LawXmlRenderOptions options)
     {
         var sentence = string.IsNullOrWhiteSpace(p.SentenceText) ? string.Empty : p.SentenceText;
-        return new("Paragraph", new XAttribute("Num", p.Number), string.IsNullOrEmpty(p.ParagraphNumText) ? new XElement("ParagraphNum") : new XElement("ParagraphNum", p.ParagraphNumText), new XElement("ParagraphSentence", new XElement("Sentence", new XAttribute("Num", 1), sentence)), p.Items.Select(RenderItem));
+        return new("Paragraph", new XAttribute("Num", p.Number), string.IsNullOrEmpty(p.ParagraphNumText) ? new XElement("ParagraphNum") : new XElement("ParagraphNum", p.ParagraphNumText), new XElement("ParagraphSentence", new XElement("Sentence", new XAttribute("Num", 1), sentence)), p.Items.Select(i => RenderItem(i, options)));
     }
 
-    private static XElement RenderItem(ItemNode i)
+    private static XElement RenderItem(ItemNode i, LawXmlRenderOptions options)
     {
-        var e = new XElement("Item", new XAttribute("Num", i.Number), new XElement("ItemTitle", ToKanji(i.Number)), new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1), i.SentenceText)));
+        var e = new XElement("Item", new XAttribute("Num", i.Number), new XElement("ItemTitle", JapaneseNumberFormatter.ToItemTitle(i.Number, options.ArabicNumbers)), new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1), i.SentenceText)));
         foreach (var child in i.Children)
         {
             e.Add(new XElement("Subitem1", new XAttribute("Num", child.Number), new XElement("Subitem1Title", child.ItemTitle), new XElement("Subitem1Sentence", new XElement("Sentence", new XAttribute("Num", 1), child.SentenceText))));
@@ -72,19 +73,4 @@ public sealed class LawXmlRenderer
 
         return e;
     }
-
-    private static string ToKanji(int n) => n switch
-    {
-        1 => "一",
-        2 => "二",
-        3 => "三",
-        4 => "四",
-        5 => "五",
-        6 => "六",
-        7 => "七",
-        8 => "八",
-        9 => "九",
-        10 => "十",
-        _ => n.ToString()
-    };
 }

--- a/src/Zuke.Core/Rendering/LawtextRenderOptions.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderOptions.cs
@@ -10,6 +10,7 @@ public sealed record LawtextRenderOptions
     public bool TrimTrailingWhitespace { get; init; } = true;
     public bool IncludeLawNum { get; init; } = true;
     public bool IncludeBlankLineBetweenBlocks { get; init; } = true;
+    public bool ArabicNumbers { get; init; }
 }
 
 public sealed record LawtextLayoutOptions

--- a/src/Zuke.Core/Rendering/LawtextRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderer.cs
@@ -1,4 +1,5 @@
 using Zuke.Core.Model;
+using Zuke.Core.Numbering;
 
 namespace Zuke.Core.Rendering;
 
@@ -37,7 +38,7 @@ public sealed class LawtextRenderer
             }
 
             writer.WriteLine(LawtextLineKind.ChapterTitle,
-                $"{options.Layout.ChapterIndent}第{ToKanji(chapter.Number)}章{options.Layout.Separator}{chapter.Title}");
+                $"{options.Layout.ChapterIndent}{JapaneseNumberFormatter.ToChapter(chapter.Number, options.ArabicNumbers)}{options.Layout.Separator}{chapter.Title}");
             hasAnyTopLevelBlock = true;
 
             foreach (var section in chapter.Sections)
@@ -48,7 +49,7 @@ public sealed class LawtextRenderer
                 }
 
                 writer.WriteLine(LawtextLineKind.SectionTitle,
-                    $"{options.Layout.SectionIndent}第{ToKanji(section.Number)}節{options.Layout.Separator}{section.Title}");
+                    $"{options.Layout.SectionIndent}{JapaneseNumberFormatter.ToSection(section.Number, options.ArabicNumbers)}{options.Layout.Separator}{section.Title}");
 
                 foreach (var article in section.Articles)
                 {
@@ -149,7 +150,7 @@ public sealed class LawtextRenderer
         foreach (var item in items)
         {
             writer.WriteLine(LawtextLineKind.Item,
-                $"{options.Layout.ItemIndent}{ToKanji(item.Number)}{options.Layout.Separator}{item.SentenceText}");
+                $"{options.Layout.ItemIndent}{JapaneseNumberFormatter.ToItemTitle(item.Number, options.ArabicNumbers)}{options.Layout.Separator}{item.SentenceText}");
 
             foreach (var subitem in item.Children)
             {
@@ -157,25 +158,6 @@ public sealed class LawtextRenderer
                     $"{options.Layout.Subitem1Indent}{subitem.ItemTitle}{options.Layout.Separator}{subitem.SentenceText}");
             }
         }
-    }
-
-    private static string ToKanji(int n)
-    {
-        if (n <= 0) return "一";
-        return n switch
-        {
-            1 => "一",
-            2 => "二",
-            3 => "三",
-            4 => "四",
-            5 => "五",
-            6 => "六",
-            7 => "七",
-            8 => "八",
-            9 => "九",
-            10 => "十",
-            _ => n.ToString()
-        };
     }
 
     private static string ToFullWidth(int n) => n.ToString()

--- a/tests/Zuke.Core.Tests/JapaneseNumberFormatterTests.cs
+++ b/tests/Zuke.Core.Tests/JapaneseNumberFormatterTests.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using Zuke.Core.Numbering;
+
+namespace Zuke.Core.Tests;
+
+public class JapaneseNumberFormatterTests
+{
+    [Theory]
+    [InlineData(11, "十一")]
+    [InlineData(12, "十二")]
+    [InlineData(20, "二十")]
+    [InlineData(21, "二十一")]
+    [InlineData(30, "三十")]
+    [InlineData(101, "百一")]
+    public void FormatsKanjiNumbers(int n, string expected)
+    {
+        Assert.Equal(expected, JapaneseNumberFormatter.ToKanjiNumber(n));
+    }
+
+    [Theory]
+    [InlineData(11, "第十一条", "第十一号")]
+    [InlineData(12, "第十二条", "第十二号")]
+    [InlineData(20, "第二十条", "第二十号")]
+    [InlineData(21, "第二十一条", "第二十一号")]
+    public void FormatsArticleAndItemReferences(int n, string article, string item)
+    {
+        Assert.Equal(article, JapaneseNumberFormatter.ToArticle(n, arabic: false));
+        Assert.Equal(item, JapaneseNumberFormatter.ToItemReference(n, arabic: false));
+    }
+}

--- a/tests/Zuke.Core.Tests/ManualReferenceDetectorTests.cs
+++ b/tests/Zuke.Core.Tests/ManualReferenceDetectorTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+
+namespace Zuke.Core.Tests;
+
+public class ManualReferenceDetectorTests
+{
+    [Fact]
+    public void DetectsReferencesAcrossTreeAndStrictMode()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+# 第一章 総則
+## 第一条
+第3条を参照する。
+## 第二節 詳細
+### 第二条
+前項を準用する。
+### 第三条
+- 第1号に従う。
+- イ 同号を読み替える。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD020" && d.Severity == Zuke.Core.Model.DiagnosticSeverity.Warning);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD028" && d.Severity == Zuke.Core.Model.DiagnosticSeverity.Warning);
+
+        var strict = TestHelpers.Compile(md, strict: true);
+        Assert.Contains(strict.Diagnostics, d => d.Code == "LMD020" && d.Severity == Zuke.Core.Model.DiagnosticSeverity.Error);
+        Assert.Contains(strict.Diagnostics, d => d.Code == "LMD028" && d.Severity == Zuke.Core.Model.DiagnosticSeverity.Error);
+    }
+
+    [Theory]
+    [InlineData("第三条第二項", "LMD020")]
+    [InlineData("次条", "LMD028")]
+    [InlineData("同項", "LMD028")]
+    public void DetectsKanjiAndRelativePatterns(string token, string expectedCode)
+    {
+        var md = $$"""
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+{{token}}に従う。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == expectedCode);
+    }
+}

--- a/tests/Zuke.Core.Tests/NumberStyleTests.cs
+++ b/tests/Zuke.Core.Tests/NumberStyleTests.cs
@@ -1,0 +1,59 @@
+using Xunit;
+using Zuke.Core.Rendering;
+
+namespace Zuke.Core.Tests;
+
+public class NumberStyleTests
+{
+    private const string Markdown = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 参照先 [条:target]
+- [号:item-12] 第十二号の対象
+
+## 参照元
+{{ref:target}}及び{{ref:item-12}}を参照する。
+""";
+
+    [Fact]
+    public void KanjiStyle_IsAppliedToLawtextXmlAndReferences()
+    {
+        var result = TestHelpers.Compile(Markdown, arabicNumbers: false);
+        Assert.NotNull(result.Document);
+
+        var lawtext = new LawtextRenderer().Render(result.Document!, LawtextRenderOptions.Default with { ArabicNumbers = false });
+        Assert.Contains("第一条", lawtext);
+        Assert.Contains("第二条", lawtext);
+        Assert.Contains("第一条及び第一条第一項第一号", lawtext);
+
+        var xml = new LawXmlRenderer().Render(result.Document!.Document, LawXmlRenderOptions.Default with { ArabicNumbers = false });
+        var xmlText = xml.ToString();
+        Assert.Contains("<ArticleTitle>第一条</ArticleTitle>", xmlText);
+        Assert.Contains("<ArticleTitle>第二条</ArticleTitle>", xmlText);
+    }
+
+    [Fact]
+    public void ArabicStyle_IsAppliedToLawtextXmlAndReferences()
+    {
+        var result = TestHelpers.Compile(Markdown, arabicNumbers: true);
+        Assert.NotNull(result.Document);
+
+        var lawtext = new LawtextRenderer().Render(result.Document!, LawtextRenderOptions.Default with { ArabicNumbers = true });
+        Assert.Contains("第1条", lawtext);
+        Assert.Contains("第2条", lawtext);
+        Assert.Contains("第1条及び第1条第1項第1号", lawtext);
+
+        var xml = new LawXmlRenderer().Render(result.Document!.Document, LawXmlRenderOptions.Default with { ArabicNumbers = true });
+        var xmlText = xml.ToString();
+        Assert.Contains("<ArticleTitle>第1条</ArticleTitle>", xmlText);
+        Assert.Contains("<ArticleTitle>第2条</ArticleTitle>", xmlText);
+        Assert.Contains("<ItemTitle>1</ItemTitle>", xmlText);
+    }
+}

--- a/tests/Zuke.Core.Tests/ReferenceNameNormalizerTests.cs
+++ b/tests/Zuke.Core.Tests/ReferenceNameNormalizerTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using Zuke.Core.References;
+
+namespace Zuke.Core.Tests;
+
+public class ReferenceNameNormalizerTests
+{
+    [Theory]
+    [InlineData("届出義務", "届出義務")]
+    [InlineData("fee-payment", "fee-payment")]
+    [InlineData("ｆｅｅ－ｐａｙｍｅｎｔ", "fee-payment")]
+    public void ValidNames_AreNormalized(string raw, string expected)
+    {
+        Assert.True(ReferenceNameNormalizer.TryNormalize(raw, out var normalized));
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("届出 義務")]
+    [InlineData("届出:義務")]
+    [InlineData("届出（義務）")]
+    public void InvalidNames_AreRejectedAndEmitLmd023(string raw)
+    {
+        Assert.False(ReferenceNameNormalizer.TryNormalize(raw, out _));
+
+        var md = $$"""
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条 [条:{{raw}}]
+本文
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD023");
+    }
+}

--- a/tests/Zuke.Core.Tests/TestHelpers.cs
+++ b/tests/Zuke.Core.Tests/TestHelpers.cs
@@ -9,24 +9,24 @@ public static class TestHelpers
 {
     public static string RepoRoot { get; } = ResolveRepoRoot();
 
-    public static CompileResult Compile(string? markdown = null, bool strict = false)
+    public static CompileResult Compile(string? markdown = null, bool strict = false, bool arabicNumbers = false)
     {
         markdown ??= ReadFixture("minimal.md");
-        return new LawMarkdownCompiler().Compile(markdown, "test.md", new CompileOptions(strict));
+        return new LawMarkdownCompiler().Compile(markdown, "test.md", new CompileOptions(strict, arabicNumbers));
     }
 
     public static string ReadFixture(string fileName)
         => File.ReadAllText(Path.Combine(RepoRoot, "tests", "Zuke.Core.Tests", "Fixtures", "Lawtext", fileName), Encoding.UTF8);
 
-    public static string RenderLawtext(string markdown)
+    public static string RenderLawtext(string markdown, bool arabicNumbers = false)
     {
-        var result = Compile(markdown);
+        var result = Compile(markdown, arabicNumbers: arabicNumbers);
         if (result.HasErrors || result.Document is null)
         {
             throw new InvalidOperationException(string.Join("\n", result.Diagnostics.Select(x => $"{x.Code}:{x.Message}")));
         }
 
-        return new LawtextRenderer().Render(result.Document, LawtextRenderOptions.Default);
+        return new LawtextRenderer().Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = arabicNumbers });
     }
 
     public static (int ExitCode, string StdOut, string StdErr) RunProcess(string fileName, string args, string? workdir = null)


### PR DESCRIPTION
### Motivation
- Handwritten manual references were only checked in direct articles and the numbering/formatting logic was duplicated, causing missed detections and inconsistent output for `kanji`/`arabic` modes.
- Reference names validation did not block several forbidden characters required by the spec, allowing invalid labels to be created.
- Number formatting beyond 10 was implemented piecemeal and produced inconsistent results across `ReferenceResolver`, `LawXmlRenderer`, and `LawtextRenderer`.

### Description
- Apply `ManualReferenceDetector` across the whole tree by enumerating all articles (direct, chapter, section) and recursively inspecting `Paragraphs`, `Items`, and `Subitem1` sentences in `LawMarkdownCompiler` using `DetectItemRecursive` and `EnumerateArticles`.
- Expand `ManualReferenceDetector` to detect numeric/kanji patterns and relative tokens via `NumericReferenceRegex` and `RelativeReferenceRegex`, splitting diagnostics into `LMD020` (handwritten numeric references) and `LMD028` (handwritten relative references) with the same strict-mode severity behavior.
- Strengthen `ReferenceNameNormalizer` to reject the specified forbidden characters (half/full-width spaces, newlines, colons, pipes, braces, brackets, parentheses, etc.) so invalid names yield `LMD023`.
- Centralize numbering via `JapaneseNumberFormatter` (added APIs like `ToArticle`, `ToChapter`, `ToSection`, `ToParagraphReference`, `ToItemReference`, `ToItemTitle`) and switch `ReferenceResolver`, `LawXmlRenderer`, `LawtextRenderer`, and `MarkdownLawParser` to use the formatter so `kanji`/`arabic` are consistent, and wire `--number-style` through CLI options into renderer options.
- Update `README.md` to document the `--number-style` behavior and add tests covering manual reference detection, reference name normalization, Japanese number formatting (including numbers >= 11), and number-style propagation.

### Testing
- Added tests: `ManualReferenceDetectorTests`, `ReferenceNameNormalizerTests`, `JapaneseNumberFormatterTests`, and `NumberStyleTests`, and updated `TestHelpers` to allow `strict`/`arabic` flags; these unit tests exercise the new detections and formatting.
- Ran `dotnet build` which succeeded, `dotnet test` which ran the test suite and passed (all tests passed), and `dotnet pack` which succeeded and produced packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01326f52c8328956a6fc5cd981e55)