### PR TITLE
Fix reference macro false positives and tighten reference-name validation

### DIFF
--- a/src/Zuke.Core/Parsing/ManualReferenceDetector.cs
+++ b/src/Zuke.Core/Parsing/ManualReferenceDetector.cs
@@ -15,12 +15,14 @@ public static class ManualReferenceDetector
 
     public static IEnumerable<DiagnosticMessage> Detect(string text, SourceLocation loc, bool strict)
     {
-        if (NumericReferenceRegex.IsMatch(text))
+        var textWithoutReferenceMacros = ReferenceParser.RefRegex.Replace(text, string.Empty);
+
+        if (NumericReferenceRegex.IsMatch(textWithoutReferenceMacros))
         {
             yield return new(strict ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning, "LMD020", "手書きの番号参照があります。", loc, Array.Empty<SourceLocation>());
         }
 
-        if (RelativeReferenceRegex.IsMatch(text))
+        if (RelativeReferenceRegex.IsMatch(textWithoutReferenceMacros))
         {
             yield return new(strict ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning, "LMD028", "手書きの相対参照があります。", loc, Array.Empty<SourceLocation>());
         }

--- a/src/Zuke.Core/Parsing/ReferenceParser.cs
+++ b/src/Zuke.Core/Parsing/ReferenceParser.cs
@@ -7,16 +7,6 @@ public static class ReferenceParser
 {
     public static readonly Regex RefRegex = new(@"\{\{(?:参照|ref):(?<name>[^|}]+)(?:\|(?<opt>[^}]+))?\}\}", RegexOptions.Compiled);
 
-    public static string ResolveInline(string text, Func<string, ReferenceOption, string> resolver)
-    {
-        return RefRegex.Replace(text, m =>
-        {
-            var name = m.Groups["name"].Value.Trim();
-            var ok = TryParseOption(m.Groups["opt"].Value.Trim(), out var opt);
-            return resolver(name, ok ? opt : ReferenceOption.Auto);
-        });
-    }
-
     public static bool TryParseOption(string opt, out ReferenceOption option)
     {
         option = ReferenceOption.Auto;

--- a/src/Zuke.Core/References/ReferenceNameNormalizer.cs
+++ b/src/Zuke.Core/References/ReferenceNameNormalizer.cs
@@ -1,16 +1,31 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Zuke.Core.References;
 
 public static class ReferenceNameNormalizer
 {
+    private static readonly Regex NumberLikeReferenceNameRegex = new(
+        @"^第(?:\d+|[一二三四五六七八九十百千]+)(?:条|項|号)$",
+        RegexOptions.Compiled);
+
     public static bool TryNormalize(string raw, out string normalized)
     {
         normalized = string.Empty;
         if (string.IsNullOrWhiteSpace(raw)) return false;
 
         var folded = ToAscii(raw.Trim().Normalize(NormalizationForm.FormKC));
-        if (folded.IndexOfAny([' ', '\u3000', '\r', '\n', ':', '|', '{', '}', '[', ']', '(', ')', '：', '（', '）']) >= 0)
+        if (folded.Any(char.IsWhiteSpace))
+        {
+            return false;
+        }
+
+        if (folded.IndexOfAny([':', '|', '{', '}', '[', ']', '(', ')', '：', '（', '）']) >= 0)
+        {
+            return false;
+        }
+
+        if (NumberLikeReferenceNameRegex.IsMatch(folded))
         {
             return false;
         }

--- a/tests/Zuke.Core.Tests/ManualReferenceDetectorTests.cs
+++ b/tests/Zuke.Core.Tests/ManualReferenceDetectorTests.cs
@@ -58,4 +58,87 @@ lang: ja
         var result = TestHelpers.Compile(md);
         Assert.Contains(result.Diagnostics, d => d.Code == expectedCode);
     }
+
+    [Theory]
+    [InlineData("{{参照:第3条}}", "LMD020")]
+    [InlineData("{{参照:第三条}}", "LMD020")]
+    [InlineData("{{ref:article-3}}", "LMD020")]
+    public void IgnoresNumericPatternsInsideReferenceMacros(string macroText, string code)
+    {
+        var md = $$"""
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+{{macroText}}に従う。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == code);
+    }
+
+    [Fact]
+    public void DetectsNumericPatternInNormalBodyText()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+第3条に従う。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD020");
+    }
+
+    [Fact]
+    public void IgnoresRelativePatternsInsideReferenceMacros()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+{{参照:前項}}に従う。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Code == "LMD028");
+    }
+
+    [Fact]
+    public void DetectsRelativePatternInNormalBodyText()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+前項に従う。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD028");
+    }
 }

--- a/tests/Zuke.Core.Tests/ReferenceNameNormalizerTests.cs
+++ b/tests/Zuke.Core.Tests/ReferenceNameNormalizerTests.cs
@@ -17,8 +17,13 @@ public class ReferenceNameNormalizerTests
 
     [Theory]
     [InlineData("届出 義務")]
+    [InlineData("届出\t義務")]
+    [InlineData("届出　義務")]
     [InlineData("届出:義務")]
     [InlineData("届出（義務）")]
+    [InlineData("第3条")]
+    [InlineData("第2項")]
+    [InlineData("第一号")]
     public void InvalidNames_AreRejectedAndEmitLmd023(string raw)
     {
         Assert.False(ReferenceNameNormalizer.TryNormalize(raw, out _));

--- a/tests/Zuke.Core.Tests/ReferenceResolverTests.cs
+++ b/tests/Zuke.Core.Tests/ReferenceResolverTests.cs
@@ -14,6 +14,33 @@ public class ReferenceResolverTests
     }
 
     [Fact]
+    public void InvalidOption_DoesNotFallBackToAuto()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条 [条:届出義務]
+本文
+
+## 第二条
+{{参照:届出義務|unknown-option}}を適用する。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.Contains(result.Diagnostics, d => d.Code == "LMD026");
+        var compiled = Assert.IsType<Zuke.Core.Model.CompiledLawDocument>(result.Document);
+        var sentence = compiled.Document.DirectArticles[1].Paragraphs[0].SentenceText;
+        Assert.Contains("届出義務を適用する。", sentence);
+        Assert.DoesNotContain("第一条を適用する。", sentence);
+    }
+
+    [Fact]
     public void DuplicateReference_HasRelatedLocations()
     {
         var md = """


### PR DESCRIPTION
### Motivation
- Avoid false positives where `ManualReferenceDetector` flags tokens that appear inside `{{参照:...}}` / `{{ref:...}}` macros as manual references.
- Prevent `ReferenceParser` from silently treating unsupported inline options as `Auto`, which contradicts the intended behavior.
- Reduce ambiguity and accidental collisions by forbidding whitespace and number-like names in reference identifiers.

### Description
- `ManualReferenceDetector.Detect` now removes reference macro spans using `ReferenceParser.RefRegex` before applying numeric and relative reference regexes, so macro internals are excluded from LMD020/LMD028 checks.
- Removed `ReferenceParser.ResolveInline` to eliminate the unsupported-option -> `Auto` fallback path and rely on `TryParseOption` for option parsing.
- `ReferenceNameNormalizer.TryNormalize` now rejects any character matching `char.IsWhiteSpace`, keeps forbidden punctuation checks, and adds `NumberLikeReferenceNameRegex` to reject names like `第3条`/`第2項`/`第一号` (emit LMD023).
- Added and updated tests in `ManualReferenceDetectorTests`, `ReferenceNameNormalizerTests`, and `ReferenceResolverTests` to cover macro-exclusion cases, whitespace/tab/full-width-space and number-like name rejections, and that unsupported options produce LMD026 without falling back to Auto.

### Testing
- Ran `dotnet build` and the solution built successfully.
- Ran `dotnet test` and all tests passed (86 passed, 0 failed).
- Ran `dotnet pack` and NuGet packages were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f017f502288328a8ee216066f8603d)