### PR TITLE
Handle leading middle-dot bullets as list items

### DIFF
--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -269,7 +269,7 @@ public sealed class MarkdownLawParser
         isSubitem1 = false;
         referenceName = null;
 
-        var labeledBullet = Regex.Match(text, @"^[-*]\s*\[(号|i):(?<name>[^\]]+)\]\s*(?<text>.+)$", RegexOptions.IgnoreCase);
+        var labeledBullet = Regex.Match(text, @"^(?:[-*]|・)\s*\[(号|i):(?<name>[^\]]+)\]\s*(?<text>.+)$", RegexOptions.IgnoreCase);
         if (labeledBullet.Success)
         {
             referenceName = labeledBullet.Groups["name"].Value.Trim();
@@ -277,7 +277,7 @@ public sealed class MarkdownLawParser
             return true;
         }
 
-        var bullet = Regex.Match(text, @"^[-*]\s*(?<text>.+)$");
+        var bullet = Regex.Match(text, @"^(?:[-*]|・)\s*(?<text>.+)$");
         if (bullet.Success)
         {
             sentence = bullet.Groups["text"].Value.Trim();

--- a/tests/Zuke.Core.Tests/MarkdownListParsingTests.cs
+++ b/tests/Zuke.Core.Tests/MarkdownListParsingTests.cs
@@ -34,4 +34,31 @@ lang: ja
         Assert.Equal("一", allItems[0].ItemTitle);
         Assert.Equal("二", allItems[1].ItemTitle);
     }
+
+    [Fact]
+    public void JapaneseMiddleDotBullets_AreParsedAsItems()
+    {
+        var md = """
+---
+lawTitle: T
+lawNum: N
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+## 第一条
+・ 通常勤務=午前8時30分始業、午後5時30分終業
+・ 時差出勤A=午前8時始業、午後5時終業
+・ [号:pattern-c] 時差出勤C=午前10時始業、午後7時終業
+""";
+        var r = TestHelpers.Compile(md);
+        Assert.False(r.HasErrors);
+        var article = Assert.Single(r.Document!.Document.DirectArticles);
+        var items = Assert.Single(article.Paragraphs).Items;
+        Assert.Equal(3, items.Count);
+        Assert.Equal("通常勤務=午前8時30分始業、午後5時30分終業", items[0].SentenceText);
+        Assert.Equal("pattern-c", items[2].ReferenceName);
+    }
 }


### PR DESCRIPTION
### Motivation
- Lawtext documents sometimes use the Japanese middle dot `・` as a leading bullet for enumerations, and those lines were not being recognized as list items causing data loss during XML conversion.

### Description
- Updated `TryParseItem` in `src/Zuke.Core/Parsing/MarkdownLawParser.cs` to recognize a leading `・` alongside `-` and `*` for both plain bullets and labeled bullets (e.g. `[号:...]`).
- Added a regression test `JapaneseMiddleDotBullets_AreParsedAsItems` in `tests/Zuke.Core.Tests/MarkdownListParsingTests.cs` that verifies `・`-prefixed lines become paragraph items and that labeled reference names are preserved.

### Testing
- Ran `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter MarkdownListParsingTests` and the filtered tests passed (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c082f4c08328b9e9feb2cdabc2d4)