### PR TITLE
HtmlDiffRenderer: side-by-side 行ペア表示を修正し行内差分ハイライトを追加

### DIFF
--- a/src/Zuke.Core/Diff/HtmlDiffRenderer.cs
+++ b/src/Zuke.Core/Diff/HtmlDiffRenderer.cs
@@ -13,7 +13,7 @@ public sealed class HtmlDiffRenderer
 
         var sb = new StringBuilder();
         sb.Append("<html><head><meta charset='utf-8'><style>");
-        sb.Append("body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;padding:16px;color:#24292f;}table{width:100%;border-collapse:collapse;table-layout:fixed;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;}th,td{border:1px solid #d0d7de;padding:4px 8px;vertical-align:top;white-space:pre-wrap;word-break:break-word;}thead th{background:#f6f8fa;} .ln{width:56px;color:#57606a;text-align:right;background:#f6f8fa;} .del{background:#ffebe9;} .add{background:#dafbe1;} .ctx{background:#ffffff;} .wrap{display:grid;grid-template-columns:1fr;gap:12px;} .summary{margin-bottom:12px;} h2{margin:0 0 8px;} ");
+        sb.Append("body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;padding:16px;color:#24292f;}table{width:100%;border-collapse:collapse;table-layout:fixed;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;}th,td{border:1px solid #d0d7de;padding:4px 8px;vertical-align:top;white-space:pre-wrap;word-break:break-word;}thead th{background:#f6f8fa;} .ln{width:56px;color:#57606a;text-align:right;background:#f6f8fa;} .del{background:#ffebe9;} .add{background:#dafbe1;} .ctx{background:#ffffff;} .del-inline{background:#ff818266;font-weight:600;} .add-inline{background:#2da44e66;font-weight:600;} .wrap{display:grid;grid-template-columns:1fr;gap:12px;} .summary{margin-bottom:12px;} h2{margin:0 0 8px;} ");
         sb.Append("</style></head><body>");
         sb.Append($"<h2>Diff: {WebUtility.HtmlEncode(oldName)} → {WebUtility.HtmlEncode(newName)}</h2>");
         sb.Append($"<div class='summary'>追加 <b>{added}</b> / 削除 <b>{removed}</b> / Hunk <b>{r.Hunks.Count}</b></div>");
@@ -25,16 +25,161 @@ public sealed class HtmlDiffRenderer
         }
         else
         {
-            foreach (var line in rows)
+            for (var i = 0; i < rows.Count; i++)
             {
-                var cls = line.Kind == '-' ? "del" : line.Kind == '+' ? "add" : "ctx";
-                var oldText = line.Kind == '+' ? string.Empty : line.Text;
-                var newText = line.Kind == '-' ? string.Empty : line.Text;
-                sb.Append($"<tr class='{cls}'><td class='ln'>{(line.OldLineNumber == 0 ? "" : line.OldLineNumber)}</td><td>{WebUtility.HtmlEncode(oldText)}</td><td class='ln'>{(line.NewLineNumber == 0 ? "" : line.NewLineNumber)}</td><td>{WebUtility.HtmlEncode(newText)}</td></tr>");
+                var line = rows[i];
+                if (line.Kind == ' ')
+                {
+                    AppendRow(sb, "ctx", line.OldLineNumber, WebUtility.HtmlEncode(line.Text), "ctx", line.NewLineNumber, WebUtility.HtmlEncode(line.Text));
+                    continue;
+                }
+
+                if (line.Kind is '+' or '-')
+                {
+                    var deletes = new List<DiffLine>();
+                    var adds = new List<DiffLine>();
+
+                    while (i < rows.Count && rows[i].Kind is '+' or '-')
+                    {
+                        if (rows[i].Kind == '-')
+                        {
+                            deletes.Add(rows[i]);
+                        }
+                        else
+                        {
+                            adds.Add(rows[i]);
+                        }
+
+                        i++;
+                    }
+
+                    i--;
+
+                    var pairCount = Math.Max(deletes.Count, adds.Count);
+                    for (var pairIndex = 0; pairIndex < pairCount; pairIndex++)
+                    {
+                        var oldLine = pairIndex < deletes.Count ? deletes[pairIndex] : null;
+                        var newLine = pairIndex < adds.Count ? adds[pairIndex] : null;
+
+                        if (oldLine is not null && newLine is not null)
+                        {
+                            var (oldText, newText) = HighlightInlineDiff(oldLine.Text, newLine.Text);
+                            AppendRow(sb, "del", oldLine.OldLineNumber, oldText, "add", newLine.NewLineNumber, newText);
+                            continue;
+                        }
+
+                        if (oldLine is not null)
+                        {
+                            AppendRow(sb, "del", oldLine.OldLineNumber, WebUtility.HtmlEncode(oldLine.Text), "ctx", 0, string.Empty);
+                            continue;
+                        }
+
+                        if (newLine is not null)
+                        {
+                            AppendRow(sb, "ctx", 0, string.Empty, "add", newLine.NewLineNumber, WebUtility.HtmlEncode(newLine.Text));
+                        }
+                    }
+                }
             }
         }
 
         sb.Append("</tbody></table></div></body></html>");
+        return sb.ToString();
+    }
+
+    private static void AppendRow(StringBuilder sb, string oldClass, int oldLineNumber, string oldText, string newClass, int newLineNumber, string newText)
+    {
+        sb.Append("<tr>");
+        sb.Append($"<td class='ln'>{(oldLineNumber == 0 ? "" : oldLineNumber)}</td>");
+        sb.Append($"<td class='{oldClass}'>{oldText}</td>");
+        sb.Append($"<td class='ln'>{(newLineNumber == 0 ? "" : newLineNumber)}</td>");
+        sb.Append($"<td class='{newClass}'>{newText}</td>");
+        sb.Append("</tr>");
+    }
+
+    private static (string oldHtml, string newHtml) HighlightInlineDiff(string oldText, string newText)
+    {
+        var oldKeep = BuildLcsKeepMap(oldText, newText, forOld: true);
+        var newKeep = BuildLcsKeepMap(oldText, newText, forOld: false);
+        return (
+            BuildHighlightedText(oldText, oldKeep, "del-inline"),
+            BuildHighlightedText(newText, newKeep, "add-inline"));
+    }
+
+    private static bool[] BuildLcsKeepMap(string oldText, string newText, bool forOld)
+    {
+        var n = oldText.Length;
+        var m = newText.Length;
+        var dp = new int[n + 1, m + 1];
+
+        for (var i = n - 1; i >= 0; i--)
+        {
+            for (var j = m - 1; j >= 0; j--)
+            {
+                if (oldText[i] == newText[j])
+                {
+                    dp[i, j] = dp[i + 1, j + 1] + 1;
+                }
+                else
+                {
+                    dp[i, j] = Math.Max(dp[i + 1, j], dp[i, j + 1]);
+                }
+            }
+        }
+
+        var oldKeep = new bool[n];
+        var newKeep = new bool[m];
+        var oi = 0;
+        var nj = 0;
+        while (oi < n && nj < m)
+        {
+            if (oldText[oi] == newText[nj])
+            {
+                oldKeep[oi] = true;
+                newKeep[nj] = true;
+                oi++;
+                nj++;
+                continue;
+            }
+
+            if (dp[oi + 1, nj] >= dp[oi, nj + 1])
+            {
+                oi++;
+            }
+            else
+            {
+                nj++;
+            }
+        }
+
+        return forOld ? oldKeep : newKeep;
+    }
+
+    private static string BuildHighlightedText(string text, bool[] keep, string cssClass)
+    {
+        var sb = new StringBuilder();
+        var inSpan = false;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (i < keep.Length && !keep[i] && !inSpan)
+            {
+                sb.Append($"<span class='{cssClass}'>");
+                inSpan = true;
+            }
+            else if (i < keep.Length && keep[i] && inSpan)
+            {
+                sb.Append("</span>");
+                inSpan = false;
+            }
+
+            sb.Append(WebUtility.HtmlEncode(text[i].ToString()));
+        }
+
+        if (inSpan)
+        {
+            sb.Append("</span>");
+        }
+
         return sb.ToString();
     }
 }

--- a/tests/Zuke.Core.Tests/HtmlDiffRendererTests.cs
+++ b/tests/Zuke.Core.Tests/HtmlDiffRendererTests.cs
@@ -18,4 +18,60 @@ public class HtmlDiffRendererTests
         Assert.Contains("<style>", html);
         Assert.Contains("Diff:", html);
     }
+
+    [Fact]
+    public void Render_SingleLineChange_IsRenderedInSameRow()
+    {
+        var html = Render("before\n", "after\n");
+
+        Assert.Contains("<td class='ln'>1</td><td class='del'>", html);
+        Assert.Contains("</td><td class='ln'>1</td><td class='add'>", html);
+    }
+
+    [Fact]
+    public void Render_TwoDeletesOneAdd_SecondDeleteHasEmptyRightSide()
+    {
+        var html = Render("a\nb\n", "x\n");
+
+        Assert.Contains("<td class='ln'>1</td><td class='del'>", html);
+        Assert.Contains("<td class='ln'>1</td><td class='add'>", html);
+        Assert.Contains("<td class='ln'>2</td><td class='del'>b</td><td class='ln'></td><td class='ctx'></td>", html);
+    }
+
+    [Fact]
+    public void Render_OneDeleteTwoAdds_SecondAddHasEmptyLeftSide()
+    {
+        var html = Render("a\n", "x\ny\n");
+
+        Assert.Contains("<td class='ln'>1</td><td class='del'>", html);
+        Assert.Contains("<td class='ln'>1</td><td class='add'>", html);
+        Assert.Contains("<td class='ln'></td><td class='ctx'></td><td class='ln'>2</td><td class='add'>y</td>", html);
+    }
+
+    [Fact]
+    public void Render_ContextLine_IsShownOnBothSides()
+    {
+        var html = Render("same\nold\n", "same\nnew\n");
+
+        Assert.Contains("<td class='ln'>1</td><td class='ctx'>same</td><td class='ln'>1</td><td class='ctx'>same</td>", html);
+    }
+
+    [Fact]
+    public void Render_PreservesHtmlEscaping()
+    {
+        var html = Render("<a>&</a>\n", "<b>&</b>\n");
+
+        Assert.Contains("&lt;", html);
+        Assert.Contains("&gt;", html);
+        Assert.Contains("&amp;", html);
+        Assert.DoesNotContain("<a>&</a>", html);
+        Assert.DoesNotContain("<b>&</b>", html);
+        Assert.DoesNotContain("<script>", html);
+    }
+
+    private static string Render(string oldText, string newText)
+    {
+        var result = new LawtextDiffService().Diff(oldText, newText, new DiffOptions(3));
+        return new HtmlDiffRenderer().Render("old.md", "new.md", result);
+    }
 }


### PR DESCRIPTION
### Motivation
- 現在の HTML 差分レンダラは削除行と追加行を別々の `<tr>` として出力しており、対応する前後行が上下にズレて見づらかったため、GitHub 風の side-by-side 表示に合わせて行を揃えたい。
- 削除/追加の数が一致しない場合や context 行の表示ルールを指定された要件に従って扱う必要があった。

### Description
- 連続する `-` / `+` ブロックを解析して削除行と追加行を上から順にペアリングし、対応ペアを同じ `<tr>` に並べて描画するロジックを導入しました（余りは空側を出力）。
- context 行は左右両側に同一行番号・本文を同一 `<tr>` で出力するように変更しました。出力の行組み立てを `AppendRow` に集約しています。
- ペアになった変更行に対して行内差分（文字単位）を LCS ベースで算出してハイライト表示を追加し、旧側は `del-inline`（濃い赤）、新側は `add-inline`（濃い緑）で強調するようにしました。
- HTML エスケープは維持したままハイライト HTML を組み立てるようにしました。
- 変更ファイル: `src/Zuke.Core/Diff/HtmlDiffRenderer.cs`、テスト追加: `tests/Zuke.Core.Tests/HtmlDiffRendererTests.cs`。

### Testing
- 実行した自動テスト: `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter HtmlDiffRendererTests`。
- 結果: フィルタされた `HtmlDiffRendererTests` の全 6 件が通過しました（Passed: 6/ Failed: 0）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e2f1467083288e8e8fdad5c23dbb)