### PR TITLE
Strengthen QA and workflow validation for Lawtext import/convert pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ zuke audit input.law.txt
 ## Lawtext import（補強）
 
 - `--reference-labels` の既定値は `all` です。
+- 既定値を `all` にする理由は、初回import時点で参照先の明示性と追跡可能性を優先し、後続の手修正を安全にするためです。
 - `--reference-labels used` は参照されている項・号を中心にラベルを出力します（条は常に出力）。
+- `--reference-labels none` はラベルを完全に省略し、人手で命名・再整理する前提の運用向けです。
+- import後の参照名は自動生成であり、必要に応じて人間がリネームできます。
 - `--report <PATH>` でインポート結果レポート（Markdown）を出力できます。
 - `--map <PATH>` で Lawtext行↔Markdown行 の対応JSONを出力できます。
 - import後Markdownは再コンパイル・再レンダリング検証されます。

--- a/docs/workflow-word-to-zuke.md
+++ b/docs/workflow-word-to-zuke.md
@@ -9,6 +9,15 @@
 7. zuke convertでLawtext/XMLへ出力する
 8. Lawtext-app等でWordへ戻す
 
+## 実行コマンド例
+
+```bash
+zuke audit samples/import-source.law.txt
+zuke import samples/import-source.law.txt -o imported.md --report import-report.md --map import-map.json
+zuke convert imported.md --to both --xml-output imported.xml --lawtext-output imported.law.txt
+zuke diff before.md imported.md --view unified
+```
+
 ## 注意点
 - zuke importは元Markdownの完全復元ではない
 - 参照名は自動生成される

--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -5,34 +5,90 @@ namespace Zuke.Core.Importing;
 
 public sealed class ExtendedMarkdownRenderer
 {
+    private const string DefaultLineNumberText = "1";
+
     public (string Markdown, List<ImportMappingItem> MappingItems) Render(LawDocumentModel model, ExtendedMarkdownRenderOptions options)
     {
         var sb = new StringBuilder();
         var mapping = new List<ImportMappingItem>();
+
         if (options.MetadataMode.Equals("frontmatter", StringComparison.OrdinalIgnoreCase))
         {
-            Append("---"); Append($"lawTitle: {model.Metadata.LawTitle}"); Append($"lawNum: {model.Metadata.LawNum}"); Append($"era: {model.Metadata.Era}"); Append($"year: {model.Metadata.Year}"); Append($"num: {model.Metadata.Num}"); Append($"lawType: {model.Metadata.LawType}"); Append($"lang: {model.Metadata.Lang}"); Append("---"); Append("");
+            Append("---");
+            Append($"lawTitle: {model.Metadata.LawTitle}");
+            Append($"lawNum: {model.Metadata.LawNum}");
+            Append($"era: {model.Metadata.Era}");
+            Append($"year: {model.Metadata.Year}");
+            Append($"num: {model.Metadata.Num}");
+            Append($"lawType: {model.Metadata.LawType}");
+            Append($"lang: {model.Metadata.Lang}");
+            Append("---");
+            Append("");
         }
-        foreach (var chapter in model.Chapters){ Append($"# {chapter.Title}"); Append(""); foreach (var section in chapter.Sections){ Append($"## 節 {section.Title}"); Append(""); foreach (var a in section.Articles) RenderArticle(a);} foreach (var a in chapter.Articles) RenderArticle(a);} foreach (var a in model.DirectArticles) RenderArticle(a);
+
+        foreach (var chapter in model.Chapters)
+        {
+            Append($"# {chapter.Title}");
+            Append("");
+            foreach (var section in chapter.Sections)
+            {
+                Append($"## 節 {section.Title}");
+                Append("");
+                foreach (var article in section.Articles) RenderArticle(article);
+            }
+            foreach (var article in chapter.Articles) RenderArticle(article);
+        }
+
+        foreach (var article in model.DirectArticles) RenderArticle(article);
+
         return (sb.ToString().Replace("\r\n","\n"), mapping);
 
         void RenderArticle(ArticleNode article)
         {
-            var label = ShouldLabel(article.ReferenceName, true) ? $" [条:{article.ReferenceName}]" : "";
+            var label = ShouldEmitLabel(article.ReferenceName, "Article") ? $" [条:{article.ReferenceName}]" : "";
             Append($"### {(string.IsNullOrWhiteSpace(article.Caption) ? $"条 {article.ReferenceName}" : article.Caption)}{label}");
-            mapping.Add(new("Article", article.Location?.Line ?? 1, GetLineNo(), $"第{article.Number}条", article.ReferenceName, article.Caption));
+            mapping.Add(CreateMapping("Article", article.Location?.Line, BuildArticleNumber(article), article.ReferenceName, article.Caption));
             Append("");
-            foreach (var p in article.Paragraphs)
+            foreach (var paragraph in article.Paragraphs) RenderParagraph(article, paragraph);
+        }
+
+        void RenderParagraph(ArticleNode article, ParagraphNode paragraph)
+        {
+            if (ShouldEmitLabel(paragraph.ReferenceName, "Paragraph")) Append($"[項:{paragraph.ReferenceName}]");
+            mapping.Add(CreateMapping("Paragraph", paragraph.Location?.Line, BuildParagraphNumber(article, paragraph), paragraph.ReferenceName, null));
+
+            if (!string.IsNullOrWhiteSpace(paragraph.SentenceText)) Append(paragraph.SentenceText);
+            foreach (var item in paragraph.Items) RenderItem(article, paragraph, item);
+            Append("");
+        }
+
+        void RenderItem(ArticleNode article, ParagraphNode paragraph, ItemNode item)
+        {
+            var label = ShouldEmitLabel(item.ReferenceName, "Item") ? $"[号:{item.ReferenceName}] " : string.Empty;
+            Append($"- {label}{item.SentenceText}");
+            mapping.Add(CreateMapping("Item", item.Location?.Line, $"{BuildParagraphNumber(article, paragraph)}第{item.Number}号", item.ReferenceName, null));
+            foreach (var subitem in item.Children)
             {
-                if (ShouldLabel(p.ReferenceName, false)) Append($"[項:{p.ReferenceName}]");
-                mapping.Add(new("Paragraph", p.Location?.Line ?? 1, GetLineNo(), $"第{article.Number}条第{p.Number}項", p.ReferenceName, null));
-                if (!string.IsNullOrWhiteSpace(p.SentenceText)) Append(p.SentenceText);
-                foreach (var i in p.Items){ var l=ShouldLabel(i.ReferenceName,false)?$"[号:{i.ReferenceName}] ":""; Append($"- {l}{i.SentenceText}");}
-                Append("");
+                Append($"  - {subitem.ItemTitle} {subitem.SentenceText}");
+                mapping.Add(CreateMapping("Subitem1", subitem.Location?.Line, $"{BuildParagraphNumber(article, paragraph)}第{item.Number}号{subitem.ItemTitle}", subitem.ReferenceName, null));
             }
         }
-        bool ShouldLabel(string? refName, bool isArticle) => options.ReferenceLabels.ToLowerInvariant() switch {"none"=>false,"used"=> isArticle || (!string.IsNullOrWhiteSpace(refName) && (options.UsedRefs?.Contains(refName)??false)), _=>true};
-        int GetLineNo() => sb.ToString().Count(c=>c=="\n"[0])+1;
-        void Append(string s)=>sb.AppendLine(s);
+
+        ImportMappingItem CreateMapping(string kind, int? lawtextLine, string number, string? referenceName, string? caption)
+            => new(kind, lawtextLine ?? 1, GetCurrentMarkdownLine(sb), number, referenceName, caption);
+
+        bool ShouldEmitLabel(string? refName, string kind)
+        {
+            var mode = options.ReferenceLabels.ToLowerInvariant();
+            if (mode == "none") return false;
+            if (mode == "all") return true;
+            if (kind == "Article") return true;
+            return !string.IsNullOrWhiteSpace(refName) && (options.UsedRefs?.Contains(refName) ?? false);
+        }
+
+        static int GetCurrentMarkdownLine(StringBuilder markdown) => markdown.ToString().Count(c=>c=='\n') + 1;
+        static string BuildArticleNumber(ArticleNode article) => $"第{article.Number}条";
+        static string BuildParagraphNumber(ArticleNode article, ParagraphNode paragraph) => $"第{article.Number}条第{paragraph.Number}項";
+        void Append(string s) => sb.AppendLine(s);
     }
 }

--- a/src/Zuke.Core/Importing/ImportReportRenderer.cs
+++ b/src/Zuke.Core/Importing/ImportReportRenderer.cs
@@ -6,6 +6,9 @@ public sealed class ImportReportRenderer
 {
     public string Render(string input, string output, LawtextImportOptions options, LawtextImportResult result)
     {
+        var generatedRefs = Extract(result.Markdown, "[条:", "[項:", "[号:");
+        var convertedRefs = Extract(result.Markdown, "{{参照:");
+        var unconvertedRefHints = result.Diagnostics.Where(x => x.Code is "LMD091" or "LMD092" or "LMD094" or "LMD095").Select(x => x.Message).Distinct().ToList();
         var sb = new StringBuilder();
         sb.AppendLine("# Lawtext Import Report");
         sb.AppendLine();
@@ -17,8 +20,30 @@ public sealed class ImportReportRenderer
         sb.AppendLine("## 診断一覧");
         foreach (var d in result.Diagnostics) sb.AppendLine($"- {d.Severity} {d.Code}: {d.Message}");
         sb.AppendLine();
+        sb.AppendLine("## 生成参照名一覧");
+        foreach (var r in generatedRefs) sb.AppendLine($"- {r}");
+        sb.AppendLine();
+        sb.AppendLine("## 変換した参照表現一覧");
+        foreach (var r in convertedRefs) sb.AppendLine($"- {r}");
+        sb.AppendLine();
+        sb.AppendLine("## 未変換の参照表現一覧");
+        foreach (var r in unconvertedRefHints) sb.AppendLine($"- {r}");
+        sb.AppendLine();
         sb.AppendLine("## roundtrip check結果");
         sb.AppendLine(result.Diagnostics.Any(x => x.Code == "LMD098") ? "- 失敗" : "- 成功");
+        sb.AppendLine();
+        sb.AppendLine("## XSD検証結果");
+        sb.AppendLine(result.Diagnostics.Any(x => x.Code == "XSD001" && x.Severity.ToString() == "Error") ? "- 失敗" : "- 成功");
+        sb.AppendLine();
+        sb.AppendLine("## 再実行コマンド例");
+        sb.AppendLine($"`zuke import {input} -o {output} --reference-labels {options.ReferenceLabels} --reference-mode {options.ReferenceMode}`");
         return sb.ToString();
+
+        static IReadOnlyList<string> Extract(string markdown, params string[] prefixes)
+            => markdown.Split('\n')
+                .SelectMany(line => prefixes.Select(prefix => (prefix, line.IndexOf(prefix, StringComparison.Ordinal))).Where(x => x.Item2 >= 0).Select(x => line[x.Item2..].Split(']').FirstOrDefault() + "]"))
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct(StringComparer.Ordinal)
+                .ToList()!;
     }
 }

--- a/src/Zuke.Core/Importing/LawtextAuditService.cs
+++ b/src/Zuke.Core/Importing/LawtextAuditService.cs
@@ -24,10 +24,14 @@ public sealed class LawtextAuditService
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i].Trim();
-            if (Regex.IsMatch(line, @"^\d+\s*/\s*\d+$") || line.Contains("Page", StringComparison.OrdinalIgnoreCase))
+            if (Regex.IsMatch(line, @"^\d+\s*/\s*\d+$") || Regex.IsMatch(line, @"^-\s*\d+\s*-$") || Regex.IsMatch(line, @"^ページ\s*\d+$") || line.Contains("Page", StringComparison.OrdinalIgnoreCase))
                 Add("LMD099", "Word由来のヘッダー/フッター/ページ番号らしき行です。", i + 1);
             if (line.Contains("第一条", StringComparison.Ordinal) && !line.StartsWith("第一条", StringComparison.Ordinal))
                 Add("LMD099", "本文途中に条番号らしき表現があります。", i + 1);
+            if (Regex.IsMatch(line, @"^第.+条の.+"))
+                Add("LMD092", "枝番付き条番号参照/条文はMVP未対応です。", i + 1);
+            if (Regex.IsMatch(line, @"^（.+）$") && (i + 1 >= lines.Length || !Regex.IsMatch(lines[i + 1].Trim(), @"^第.+条")))
+                Add("LMD099", "ArticleCaptionらしき行の直後に条文がありません。", i + 1);
         }
 
         return new LawtextAuditResult(all);

--- a/tests/Zuke.Core.Tests/QualityWorkflowTests.cs
+++ b/tests/Zuke.Core.Tests/QualityWorkflowTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using Xunit;
+using Zuke.Core.Importing;
+
+namespace Zuke.Core.Tests;
+
+public class LawtextAuditTests
+{
+    [Theory]
+    [InlineData("第一条　前条による。", "LMD091")]
+    [InlineData("第一条\n  一　前号による。", "LMD091")]
+    [InlineData("第一条\n前項による。", "LMD091")]
+    [InlineData("第一条　第三条第一項による。", "LMD092")]
+    [InlineData("第一条　第一号から第三号まで。", "LMD095")]
+    [InlineData("第一条　第一条及び第二条による。", "LMD094")]
+    [InlineData("第二条の二　追加条文。", "LMD092")]
+    public void ImportDiagnosticsForKnownPatterns(string body, string expectedCode)
+    {
+        var lawtext = $"題名\n（令和六年規則第一号）\n\n{body}\n";
+        var import = new LawtextImportService().Import(lawtext, "x.law.txt", new());
+        var audit = new LawtextAuditService().Audit(lawtext, "x.law.txt", false);
+        Assert.True(import.Diagnostics.Any(d => d.Code == expectedCode) || audit.Diagnostics.Any(d => d.Code == expectedCode));
+    }
+
+    [Theory]
+    [InlineData("（目的）\n\n", "LMD099")]
+    [InlineData("題名\n（令和六年規則第一号）\n\n- 1 -\n", "LMD099")]
+    [InlineData("題名\n（令和六年規則第一号）\n\nページ 1\n", "LMD099")]
+    [InlineData("題名\n（令和六年規則第一号）\n\nこれは孤立本文です。\n", "LMD096")]
+    public void AuditDiagnosticsForMalformedBody(string lawtext, string code)
+    {
+        var result = new LawtextAuditService().Audit(lawtext, "x.law.txt", false);
+        Assert.Contains(result.Diagnostics, d => d.Code == code || d.Code == "LMD099");
+    }
+}
+
+public class ImportReportTests
+{
+    [Fact]
+    public void ReportContainsOperationalSections()
+    {
+        var md = Path.GetTempFileName();
+        var report = Path.GetTempFileName();
+        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {md} --report {report}");
+        Assert.Equal(0, run.ExitCode);
+        var text = File.ReadAllText(report);
+        Assert.Contains("Input:", text);
+        Assert.Contains("Output:", text);
+        Assert.Contains("Reference Labels", text);
+        Assert.Contains("診断一覧", text);
+        Assert.Contains("生成参照名一覧", text);
+        Assert.Contains("変換した参照表現一覧", text);
+        Assert.Contains("未変換の参照表現一覧", text);
+        Assert.Contains("roundtrip check結果", text);
+        Assert.Contains("XSD検証結果", text);
+        Assert.Contains("再実行コマンド例", text);
+    }
+}
+
+public class ImportMapTests
+{
+    [Fact]
+    public void MapContainsReadableAndTraceableItems()
+    {
+        var src = Path.GetTempFileName();
+        File.WriteAllText(src, "題名\n（令和六年規則第一号）\n\n第一条\n  一　項本文\n    イ　子号本文\n");
+        var md = Path.GetTempFileName();
+        var map = Path.GetTempFileName();
+        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import {src} -o {md} --map {map} --reference-labels used");
+        Assert.Equal(0, run.ExitCode);
+        var json = File.ReadAllText(map);
+        Assert.Contains("\"Kind\": \"Article\"", json);
+        Assert.Contains("\"Kind\": \"Paragraph\"", json);
+        Assert.Contains("\"Kind\": \"Item\"", json);
+        Assert.Contains("\"LawtextLine\":", json);
+        Assert.Contains("\"MarkdownLine\":", json);
+        Assert.Contains("\"Number\":", json);
+        Assert.Contains("\"ReferenceName\":", json);
+    }
+}
+
+public class ConvertBothTests
+{
+    [Fact]
+    public void ConvertBothCreatesXmlAndLawtext()
+    {
+        var xml = Path.GetTempFileName();
+        var law = Path.GetTempFileName();
+        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --xml-output {xml} --lawtext-output {law}");
+        Assert.Equal(0, run.ExitCode);
+        Assert.True(File.Exists(xml));
+        Assert.True(File.Exists(law));
+        var lawtext = File.ReadAllText(law);
+        Assert.DoesNotContain("{{参照:", lawtext);
+        Assert.DoesNotContain("🍣", lawtext);
+    }
+
+    [Fact]
+    public void ConvertBothRejectsInvalidOutputOptions()
+    {
+        var run1 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both -o out.xml");
+        var run2 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --xml-output out.xml");
+        var run3 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --lawtext-output out.law.txt");
+        Assert.NotEqual(0, run1.ExitCode);
+        Assert.NotEqual(0, run2.ExitCode);
+        Assert.NotEqual(0, run3.ExitCode);
+    }
+}
+
+public class WordToZukeWorkflowAcceptanceTests
+{
+    [Fact]
+    public void EndToEndWorkflowWorks()
+    {
+        var md = Path.GetTempFileName();
+        var xml = Path.GetTempFileName();
+        var law = Path.GetTempFileName();
+
+        var audit = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- audit samples/import-source.law.txt");
+        Assert.Equal(0, audit.ExitCode);
+
+        var import = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {md}");
+        Assert.Equal(0, import.ExitCode);
+
+        var convert = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- convert {md} --to both --xml-output {xml} --lawtext-output {law}");
+        Assert.Equal(0, convert.ExitCode);
+        var lawtext = File.ReadAllText(law);
+        Assert.DoesNotContain("{{参照:", lawtext);
+        Assert.DoesNotContain("🍣", lawtext);
+
+        File.AppendAllText(md, "\n### （追加条） [条:追加条]\n追加本文\n");
+        var diff = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- diff samples/work-rules.md {md}");
+        Assert.NotEqual(0, diff.ExitCode);
+    }
+}


### PR DESCRIPTION
### Motivation

- Harden the real-world workflow (Word → AI Lawtext → `zuke audit` → `zuke import` → edit → `zuke convert --to both`) so zuke is safe and predictable in practice. 
- Improve detection of malformed AI/Word outputs and provide richer import reporting and mapping so users can trace and fix issues after import.
- Make `ExtendedMarkdownRenderer` more maintainable to reduce future regressions and enable clearer mapping output.

### Description

- Refactored `ExtendedMarkdownRenderer` to separate `RenderArticle`, `RenderParagraph`, and `RenderItem`, centralized mapping creation, line-number calculation, and `used/all/none` label logic, and added explicit `Subitem1` output and mapping. (see `src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs`) 
- Extended `ImportReportRenderer` to include generated reference names, converted reference expressions, unconverted reference hints, roundtrip/XSD summaries, and a sample rerun command in the report. (see `src/Zuke.Core/Importing/ImportReportRenderer.cs`) 
- Enhanced `LawtextAuditService` heuristics to catch Word header/footer/page patterns (e.g. `- 1 -`, `ページ 1`), branch-numbered articles (e.g. `第二条の二`), and orphan article-caption-like lines, emitting targeted diagnostics. (see `src/Zuke.Core/Importing/LawtextAuditService.cs`) 
- Added a comprehensive test suite (`tests/Zuke.Core.Tests/QualityWorkflowTests.cs`) covering: audit negative cases, import report content, import mapping structure, `convert --to both` success/error conditions, and an end-to-end Word→zuke acceptance workflow. 
- Updated `README.md` and `docs/workflow-word-to-zuke.md` with practical notes about import limitations, `--reference-labels` policy, and command examples for the documented workflow.

### Testing

- Ran `dotnet build` successfully. 
- Ran `dotnet test` and all tests passed (new suite included); the test run completed with all tests green. 
- Ran `dotnet pack` successfully to ensure packaging succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12d4c71988328b230db942f2f8227)