### PR TITLE
Add first-class support for branch-numbered articles (第19条の2 etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,7 @@ zuke audit input.law.txt
 ```bash
 zuke convert input.md --to both --xml-output output.xml --lawtext-output output.law.txt
 ```
+
+## 枝番号付きArticle
+
+zukeは第19条の2・第十九条の二・第38条の3の2のような枝番号付きArticleを、独立したArticleとして扱います。第19条の2は第19条の下位要素ではなく、同じ階層に並ぶ独立した条であり、既存条番号を変えずに途中へ条を差し込むための番号です。XMLでは `Article Num="19_2"` 形式で出力し、import時は `[条:article-19-2]` の参照名を生成します。

--- a/docs/workflow-word-to-zuke.md
+++ b/docs/workflow-word-to-zuke.md
@@ -25,3 +25,5 @@ zuke diff before.md imported.md --view unified
 - 表・別表・附則・様式はMVPでは手動確認が必要
 - AI変換結果は必ず人間が確認する
 - Wordは最終出力形式とし、編集元はMarkdownに寄せることを推奨する
+
+> 実務文書では「第9条の2」のような枝番号付きArticleが使われます。zukeではこれを第9条の下位要素ではなく、第9条と同じ階層に並ぶ独立したArticleとして取り扱います。

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -10,7 +10,7 @@ public sealed class LawtextParser
     private static readonly Regex ChapterRegex = new(@"^\s*第(?<n>[0-9０-９一二三四五六七八九十百千]+)章\s+[　 ]*(?<t>.+)$", RegexOptions.Compiled);
     private static readonly Regex SectionRegex = new(@"^\s*第(?<n>[0-9０-９一二三四五六七八九十百千]+)節\s+[　 ]*(?<t>.+)$", RegexOptions.Compiled);
     private static readonly Regex CaptionRegex = new(@"^\s*（(?<t>.+)）\s*$", RegexOptions.Compiled);
-    private static readonly Regex ArticleRegex = new(@"^第(?<n>[0-9０-９一二三四五六七八九十百千]+)条\s*[　 ]*(?<s>.*)$", RegexOptions.Compiled);
+    private static readonly Regex ArticleRegex = new(@"^(?<num>第[0-9０-９一二三四五六七八九十百千]+条(の[0-9０-９一二三四五六七八九十百千]+)*)\s*[　 ]*(?<s>.*)$", RegexOptions.Compiled);
     private static readonly Regex ParagraphRegex = new(@"^(?<n>[0-9０-９]+)\s*[　 ]*(?<s>.*)$", RegexOptions.Compiled);
     private static readonly Regex ItemRegex = new(@"^\s*(?<n>[一二三四五六七八九十]+)\s*[　 ](?<s>.+)$", RegexOptions.Compiled);
     private static readonly Regex Subitem1Regex = new(@"^\s*(?<n>[イロハニホヘトチリヌルヲワカヨタレソツネナラムウヰノオクヤマケフコエテ])\s*[　 ](?<s>.+)$", RegexOptions.Compiled);
@@ -88,8 +88,14 @@ public sealed class LawtextParser
             if (article.Success)
             {
                 FlushArticle();
-                var n = ParseNumber(article.Groups["n"].Value);
-                currentArticle = new(n, null, pendingCaption ?? "", JapaneseNumberFormatter.ToArticle(n, false), new(filePath, i + 1, 1), []);
+                var articleText = article.Groups["num"].Value;
+                if (!ArticleNumberFormatter.TryParseArticleNumber(articleText, out var articleNumber))
+                {
+                    diags.Add(new(DiagnosticSeverity.Warning, "LMD101", "Article枝番号の形式が不正です。", new(filePath, i + 1, 1), []));
+                    continue;
+                }
+                var n = articleNumber.BaseNumber;
+                currentArticle = new(n, null, pendingCaption ?? "", ArticleNumberFormatter.ToArticleTitle(articleNumber, false), new(filePath, i + 1, 1), []) { ArticleNumber = articleNumber };
                 pendingCaption = null;
                 currentParagraph = new(1, null, null, article.Groups["s"].Value.Trim(), new(filePath, i + 1, 1), []);
                 items = [];
@@ -212,7 +218,7 @@ public sealed class LawtextParser
         return true;
     }
 
-    internal static int ParseNumber(string text)
+    public static int ParseNumber(string text)
     {
         var normalized = text.Trim()
             .Replace("０", "0", StringComparison.Ordinal).Replace("１", "1", StringComparison.Ordinal)

--- a/src/Zuke.Core/Importing/ReferenceNameGenerator.cs
+++ b/src/Zuke.Core/Importing/ReferenceNameGenerator.cs
@@ -1,3 +1,4 @@
+using Zuke.Core.Numbering;
 using Zuke.Core.Model;
 
 namespace Zuke.Core.Importing;
@@ -28,7 +29,7 @@ public sealed class ReferenceNameGenerator
 
     private static ArticleNode ApplyAsciiArticle(ArticleNode article)
     {
-        var articleRef = $"article-{article.Number}";
+        var articleRef = Numbering.ArticleNumberFormatter.ToReferenceName(article.ArticleNumber);
         var paragraphs = article.Paragraphs.Select(p => p with
         {
             ReferenceName = $"{articleRef}-p{p.Number}",

--- a/src/Zuke.Core/Model/ArticleNode.cs
+++ b/src/Zuke.Core/Model/ArticleNode.cs
@@ -1,2 +1,7 @@
+using Zuke.Core.Numbering;
+
 namespace Zuke.Core.Model;
-public sealed record ArticleNode(int Number,string? ReferenceName,string Caption,string ArticleTitle,SourceLocation? Location,IReadOnlyList<ParagraphNode> Paragraphs);
+public sealed record ArticleNode(int Number,string? ReferenceName,string Caption,string ArticleTitle,SourceLocation? Location,IReadOnlyList<ParagraphNode> Paragraphs)
+{
+    public ArticleNumber ArticleNumber { get; init; } = ArticleNumber.FromBase(Number);
+}

--- a/src/Zuke.Core/Numbering/ArticleNumber.cs
+++ b/src/Zuke.Core/Numbering/ArticleNumber.cs
@@ -1,0 +1,8 @@
+namespace Zuke.Core.Numbering;
+
+public sealed record ArticleNumber(int BaseNumber, IReadOnlyList<int> BranchNumbers)
+{
+    public bool HasBranch => BranchNumbers.Count > 0;
+
+    public static ArticleNumber FromBase(int n) => new(n, []);
+}

--- a/src/Zuke.Core/Numbering/ArticleNumberFormatter.cs
+++ b/src/Zuke.Core/Numbering/ArticleNumberFormatter.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+namespace Zuke.Core.Numbering;
+
+public static class ArticleNumberFormatter
+{
+    private static readonly Regex ArticleNumberRegex = new(@"^第(?<base>[0-9０-９一二三四五六七八九十百千]+)条(?<branch>(の[0-9０-９一二三四五六七八九十百千]+)*)$", RegexOptions.Compiled);
+
+    public static bool TryParseArticleNumber(string text, out ArticleNumber number)
+    {
+        number = ArticleNumber.FromBase(0);
+        var m = ArticleNumberRegex.Match(text.Trim());
+        if (!m.Success) return false;
+        var baseNumber = LawtextImportingNumber(m.Groups["base"].Value);
+        var rawBranch = m.Groups["branch"].Value;
+        var branches = new List<int>();
+        if (!string.IsNullOrEmpty(rawBranch))
+        {
+            foreach (var token in rawBranch.Split('の', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var b = LawtextImportingNumber(token);
+                if (b <= 0) return false;
+                branches.Add(b);
+            }
+        }
+
+        if (baseNumber <= 0) return false;
+        number = new ArticleNumber(baseNumber, branches);
+        return true;
+    }
+
+    public static ArticleNumber ParseArticleNumber(string text)
+        => TryParseArticleNumber(text, out var n) ? n : throw new FormatException($"Invalid article number format: {text}");
+
+    public static string ToArticleTitle(ArticleNumber number, bool arabic)
+    {
+        var baseText = arabic ? number.BaseNumber.ToString() : JapaneseNumberFormatter.ToKanjiNumber(number.BaseNumber);
+        var branchText = string.Concat(number.BranchNumbers.Select(b => $"の{(arabic ? b.ToString() : JapaneseNumberFormatter.ToKanjiNumber(b))}"));
+        return $"第{baseText}条{branchText}";
+    }
+
+    public static string ToXmlNum(ArticleNumber number) => string.Join("_", new[] { number.BaseNumber }.Concat(number.BranchNumbers));
+    public static string ToReferenceName(ArticleNumber number) => "article-" + string.Join("-", new[] { number.BaseNumber }.Concat(number.BranchNumbers));
+
+    private static int LawtextImportingNumber(string text)
+    {
+        return Importing.LawtextParser.ParseNumber(text);
+    }
+}

--- a/src/Zuke.Core/Numbering/NumberingService.cs
+++ b/src/Zuke.Core/Numbering/NumberingService.cs
@@ -24,6 +24,7 @@ public sealed class NumberingService
     private static ArticleNode RenumberArticle(ArticleNode a, int no, bool arabic)
     {
         var ps = a.Paragraphs.Select((p,idx)=> p with { Number = idx+1, ParagraphNumText = JapaneseNumberFormatter.ToParagraphNum(idx+1)}).ToList();
-        return a with { Number = no, ArticleTitle = JapaneseNumberFormatter.ToArticle(no, arabic), Paragraphs = ps };
+        var articleNumber = a.ArticleNumber.BaseNumber > 0 ? a.ArticleNumber : ArticleNumber.FromBase(no);
+        return a with { Number = no, ArticleNumber = articleNumber, ArticleTitle = ArticleNumberFormatter.ToArticleTitle(articleNumber, arabic), Paragraphs = ps };
     }
 }

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -10,7 +10,7 @@ public sealed class MarkdownLawParser
     private static readonly Regex LabelRegex = new(@"\[(条|項|号|a|p|i):(?<name>[^\]]+)\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex NumberedChapterRegex = new(@"^第[0-9０-９一二三四五六七八九十百千]+章\s*(?<title>.+)$", RegexOptions.Compiled);
     private static readonly Regex NumberedSectionRegex = new(@"^第[0-9０-９一二三四五六七八九十百千]+節\s*(?<title>.+)$", RegexOptions.Compiled);
-    private static readonly Regex NumberedArticleRegex = new(@"^第[0-9０-９一二三四五六七八九十百千]+条\s*(?<title>.+)$", RegexOptions.Compiled);
+    private static readonly Regex NumberedArticleRegex = new(@"^(?<num>第[0-9０-９一二三四五六七八九十百千]+条(の[0-9０-９一二三四五六七八九十百千]+)*)\s*(?<title>.+)$", RegexOptions.Compiled);
 
     public LawDocumentModel Parse(string markdown, string? filePath)
     {
@@ -81,7 +81,13 @@ public sealed class MarkdownLawParser
                     paragraphs.Add(new ParagraphNode(1, null, null, string.Empty, new(filePath, articleStart, 1), []));
                 }
 
-                var article = new ArticleNode(articleNo, articleRefName, caption, JapaneseNumberFormatter.ToArticle(articleNo, false), new(filePath, articleStart, 1), paragraphs);
+                var articleNumber = ArticleNumber.FromBase(articleNo);
+                var numbered = NumberedArticleRegex.Match(line.StartsWith("### ", StringComparison.Ordinal) ? line[4..].Trim() : line[3..].Trim());
+                if (numbered.Success && ArticleNumberFormatter.TryParseArticleNumber(numbered.Groups["num"].Value, out var parsedNumber))
+                {
+                    articleNumber = parsedNumber;
+                }
+                var article = new ArticleNode(articleNo, articleRefName, caption, ArticleNumberFormatter.ToArticleTitle(articleNumber, false), new(filePath, articleStart, 1), paragraphs) { ArticleNumber = articleNumber };
                 if (currentSection is not null) secArticles.Add(article);
                 else if (currentChapter is not null) chArticles.Add(article);
                 else direct.Add(article);

--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -40,8 +40,8 @@ public sealed class LawXmlRenderer
     {
         var elements = new List<object>
         {
-            new XAttribute("Num", a.Number),
-            new XElement("ArticleTitle", JapaneseNumberFormatter.ToArticle(a.Number, options.ArabicNumbers))
+            new XAttribute("Num", ArticleNumberFormatter.ToXmlNum(a.ArticleNumber)),
+            new XElement("ArticleTitle", ArticleNumberFormatter.ToArticleTitle(a.ArticleNumber, options.ArabicNumbers))
         };
 
         if (!string.IsNullOrWhiteSpace(a.Caption))

--- a/tests/Zuke.Core.Tests/ArticleNumberTests.cs
+++ b/tests/Zuke.Core.Tests/ArticleNumberTests.cs
@@ -1,0 +1,31 @@
+using Xunit;
+using Zuke.Core.Numbering;
+
+namespace Zuke.Core.Tests;
+
+public class ArticleNumberTests
+{
+    [Theory]
+    [InlineData("第19条",19)]
+    [InlineData("第19条の2",19)]
+    [InlineData("第十九条",19)]
+    [InlineData("第十九条の二",19)]
+    [InlineData("第38条の3の2",38)]
+    [InlineData("第三十八条の三の二",38)]
+    public void ParseArticleNumber_Works(string text, int expectedBase)
+    {
+        var ok = ArticleNumberFormatter.TryParseArticleNumber(text, out var n);
+        Assert.True(ok);
+        Assert.Equal(expectedBase, n.BaseNumber);
+    }
+
+    [Fact]
+    public void Formatter_Works()
+    {
+        var n = new ArticleNumber(19, [2]);
+        Assert.Equal("19_2", ArticleNumberFormatter.ToXmlNum(n));
+        Assert.Equal("第十九条の二", ArticleNumberFormatter.ToArticleTitle(n, false));
+        Assert.Equal("第19条の2", ArticleNumberFormatter.ToArticleTitle(n, true));
+        Assert.Equal("article-19-2", ArticleNumberFormatter.ToReferenceName(n));
+    }
+}


### PR DESCRIPTION
### Motivation
- Practical laws/regulations use branch-numbered article labels (e.g. 第9条の2 / 第十九条の二 / 第38条の3の2) which must be treated as independent Articles, not sub-elements. 
- Existing model assumed `Article.Number` as an `int` and flagged branch formats as MVP-missing; we need a small, compatible model change to support branch numbers without large refactors.

### Description
- Added `ArticleNumber` value object and `ArticleNumberFormatter` utilities to parse/format branch article identifiers (API: `TryParseArticleNumber` / `ParseArticleNumber`, `ToArticleTitle`, `ToXmlNum`, `ToReferenceName`).
- Extended `ArticleNode` with an `ArticleNumber` property while keeping the existing `Number` field for compatibility and backward ordering.
- Updated `LawtextParser` and `MarkdownLawParser` to recognize branch-numbered article headings as independent `Article` nodes and emit diagnostic `LMD101` only when the branch format is malformed.
- Updated `ReferenceNameGenerator`, `NumberingService`, and `LawXmlRenderer` to use `ArticleNumber` for canonical reference names and XML `Num` (underscore format, e.g. `19_2`) and to preserve imported explicit article numbers when present.
- Added unit tests `ArticleNumberTests` for parsing/formatting behavior and documentation updates in `README.md` and `docs/workflow-word-to-zuke.md` explaining that branch-numbered articles are independent Articles.

### Testing
- `dotnet build` succeeded.
- `dotnet test` succeeded: all tests passed (Passed: 133, Failed: 0).
- `dotnet pack` succeeded and produced packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14623a4188328bf533ba75b3132c3)