### PR TITLE
Validate branch-article tokens in audit and modernize CLI test helpers

### DIFF
--- a/src/Zuke.Core/Importing/LawtextAuditService.cs
+++ b/src/Zuke.Core/Importing/LawtextAuditService.cs
@@ -5,6 +5,8 @@ namespace Zuke.Core.Importing;
 
 public sealed class LawtextAuditService
 {
+    private static readonly Regex BranchArticleTokenRegex = new(@"^(?<num>第\S+?)(?:\s+|　+|$)", RegexOptions.Compiled);
+
     public LawtextAuditResult Audit(string lawtext, string? path, bool strict)
     {
         var parser = new LawtextParser();
@@ -28,8 +30,12 @@ public sealed class LawtextAuditService
                 Add("LMD099", "Word由来のヘッダー/フッター/ページ番号らしき行です。", i + 1);
             if (line.Contains("第一条", StringComparison.Ordinal) && !line.StartsWith("第一条", StringComparison.Ordinal))
                 Add("LMD099", "本文途中に条番号らしき表現があります。", i + 1);
-            if (line.StartsWith("第", StringComparison.Ordinal) && line.Contains("条の", StringComparison.Ordinal) && !Numbering.ArticleNumberFormatter.TryParseArticleNumber(line.Split("　")[0], out _))
-                Add("LMD101", "枝番号付き条番号の形式が不正です。", i + 1);
+            if (line.StartsWith("第", StringComparison.Ordinal) && line.Contains("条の", StringComparison.Ordinal))
+            {
+                var m = BranchArticleTokenRegex.Match(line);
+                if (!m.Success || !Numbering.ArticleNumberFormatter.TryParseArticleNumber(m.Groups["num"].Value, out _))
+                    Add("LMD101", "枝番号付き条番号の形式が不正です。", i + 1);
+            }
             if (Regex.IsMatch(line, @"^（.+）$") && (i + 1 >= lines.Length || !Regex.IsMatch(lines[i + 1].Trim(), @"^第.+条")))
                 Add("LMD099", "ArticleCaptionらしき行の直後に条文がありません。", i + 1);
         }

--- a/tests/Zuke.Core.Tests/ImportEnhancementCliTests.cs
+++ b/tests/Zuke.Core.Tests/ImportEnhancementCliTests.cs
@@ -7,11 +7,12 @@ public class ImportEnhancementCliTests
     [Fact]
     public void ImportCommandCreatesReportAndMap()
     {
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "import-source.law.txt");
         var md = Path.GetTempFileName();
         var report = Path.GetTempFileName();
         var map = Path.GetTempFileName();
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {md} --report {report} --map {map}");
-        Assert.Equal(0, run.ExitCode);
+        var run = TestHelpers.RunZuke($"import {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(md)} --report {TestHelpers.QuoteArg(report)} --map {TestHelpers.QuoteArg(map)}");
+        TestHelpers.AssertExitCode(run, 0);
         Assert.Contains("Lawtext Import Report", File.ReadAllText(report));
         var json = File.ReadAllText(map);
         Assert.Contains("\"Kind\": \"Article\"", json);
@@ -21,7 +22,8 @@ public class ImportEnhancementCliTests
     [Fact]
     public void AuditCommandWorks()
     {
-        var run = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- audit samples/import-source.law.txt");
-        Assert.Equal(0, run.ExitCode);
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "import-source.law.txt");
+        var run = TestHelpers.RunZuke($"audit {TestHelpers.QuoteArg(input)}");
+        TestHelpers.AssertExitCode(run, 0);
     }
 }

--- a/tests/Zuke.Core.Tests/LawtextCliIntegrationTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextCliIntegrationTests.cs
@@ -8,14 +8,16 @@ public class LawtextCliIntegrationTests
     [Fact]
     public void LawtextAndConvertOutputsMatch()
     {
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "work-rules.md");
+        Assert.True(File.Exists(input), $"Missing sample file: {input}");
         var out1 = Path.GetTempFileName();
         var out2 = Path.GetTempFileName();
 
-        var run1 = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- lawtext samples/work-rules.md -o {out1}");
-        var run2 = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- convert samples/work-rules.md -o {out2} --to lawtext");
+        var run1 = TestHelpers.RunZuke($"lawtext {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(out1)}");
+        var run2 = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(out2)} --to lawtext");
 
-        Assert.Equal(0, run1.ExitCode);
-        Assert.Equal(0, run2.ExitCode);
+        TestHelpers.AssertExitCode(run1, 0);
+        TestHelpers.AssertExitCode(run2, 0);
 
         var bytes = File.ReadAllBytes(out1);
         Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
@@ -38,8 +40,8 @@ public class LawtextCliIntegrationTests
         File.WriteAllText(oldMd, TestHelpers.ReadFixture("references.md"));
         File.WriteAllText(newMd, TestHelpers.ReadFixture("references.md").Replace("届け出なければ", "提出しなければ"));
 
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- diff {oldMd} {newMd}");
-        Assert.Equal(1, run.ExitCode);
+        var run = TestHelpers.RunZuke($"diff {TestHelpers.QuoteArg(oldMd)} {TestHelpers.QuoteArg(newMd)}");
+        TestHelpers.AssertExitCode(run, 1);
         Assert.Contains("+", run.StdOut);
     }
 }

--- a/tests/Zuke.Core.Tests/LawtextImportCliTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportCliTests.cs
@@ -7,9 +7,11 @@ public class LawtextImportCliTests
     [Fact]
     public void ImportCommandCreatesMarkdown()
     {
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "import-source.law.txt");
+        Assert.True(File.Exists(input), $"Missing sample file: {input}");
         var outPath = Path.GetTempFileName();
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {outPath}");
-        Assert.Equal(0, run.ExitCode);
+        var run = TestHelpers.RunZuke($"import {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(outPath)}");
+        TestHelpers.AssertExitCode(run, 0);
         var md = File.ReadAllText(outPath);
         Assert.Contains("---", md);
         Assert.Contains("# 総則", md);

--- a/tests/Zuke.Core.Tests/QualityWorkflowTests.cs
+++ b/tests/Zuke.Core.Tests/QualityWorkflowTests.cs
@@ -32,6 +32,21 @@ public class LawtextAuditTests
         var result = new LawtextAuditService().Audit(lawtext, "x.law.txt", false);
         Assert.Contains(result.Diagnostics, d => d.Code == code || d.Code == "LMD099");
     }
+
+    [Theory]
+    [InlineData("第9条の2　本文。", false)]
+    [InlineData("第9条の2 本文。", false)]
+    [InlineData("第九条の二 本文。", false)]
+    [InlineData("第38条の3の2 本文。", false)]
+    [InlineData("第9条のA 本文。", true)]
+    [InlineData("第9条の0 本文。", true)]
+    [InlineData("第9条の二の 本文。", true)]
+    public void Audit_BranchArticleValidation_Works(string articleLine, bool expectLmd101)
+    {
+        var lawtext = $"題名\n（令和六年規則第一号）\n\n{articleLine}\n";
+        var result = new LawtextAuditService().Audit(lawtext, "x.law.txt", false);
+        Assert.Equal(expectLmd101, result.Diagnostics.Any(d => d.Code == "LMD101"));
+    }
 }
 
 public class ImportReportTests
@@ -41,8 +56,9 @@ public class ImportReportTests
     {
         var md = Path.GetTempFileName();
         var report = Path.GetTempFileName();
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {md} --report {report}");
-        Assert.Equal(0, run.ExitCode);
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "import-source.law.txt");
+        var run = TestHelpers.RunZuke($"import {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(md)} --report {TestHelpers.QuoteArg(report)}");
+        TestHelpers.AssertExitCode(run, 0);
         var text = File.ReadAllText(report);
         Assert.Contains("Input:", text);
         Assert.Contains("Output:", text);
@@ -66,8 +82,8 @@ public class ImportMapTests
         File.WriteAllText(src, "題名\n（令和六年規則第一号）\n\n第一条\n  一　項本文\n    イ　子号本文\n");
         var md = Path.GetTempFileName();
         var map = Path.GetTempFileName();
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import {src} -o {md} --map {map} --reference-labels used");
-        Assert.Equal(0, run.ExitCode);
+        var run = TestHelpers.RunZuke($"import {TestHelpers.QuoteArg(src)} -o {TestHelpers.QuoteArg(md)} --map {TestHelpers.QuoteArg(map)} --reference-labels used");
+        TestHelpers.AssertExitCode(run, 0);
         var json = File.ReadAllText(map);
         Assert.Contains("\"Kind\": \"Article\"", json);
         Assert.Contains("\"Kind\": \"Paragraph\"", json);
@@ -86,8 +102,9 @@ public class ConvertBothTests
     {
         var xml = Path.GetTempFileName();
         var law = Path.GetTempFileName();
-        var run = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --xml-output {xml} --lawtext-output {law}");
-        Assert.Equal(0, run.ExitCode);
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "work-rules.md");
+        var run = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} --to both --xml-output {TestHelpers.QuoteArg(xml)} --lawtext-output {TestHelpers.QuoteArg(law)}");
+        TestHelpers.AssertExitCode(run, 0);
         Assert.True(File.Exists(xml));
         Assert.True(File.Exists(law));
         var lawtext = File.ReadAllText(law);
@@ -98,9 +115,10 @@ public class ConvertBothTests
     [Fact]
     public void ConvertBothRejectsInvalidOutputOptions()
     {
-        var run1 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both -o out.xml");
-        var run2 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --xml-output out.xml");
-        var run3 = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- convert samples/work-rules.md --to both --lawtext-output out.law.txt");
+        var input = Path.Combine(TestHelpers.RepoRoot, "samples", "work-rules.md");
+        var run1 = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} --to both -o out.xml");
+        var run2 = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} --to both --xml-output out.xml");
+        var run3 = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} --to both --lawtext-output out.law.txt");
         Assert.NotEqual(0, run1.ExitCode);
         Assert.NotEqual(0, run2.ExitCode);
         Assert.NotEqual(0, run3.ExitCode);
@@ -116,20 +134,22 @@ public class WordToZukeWorkflowAcceptanceTests
         var xml = Path.GetTempFileName();
         var law = Path.GetTempFileName();
 
-        var audit = TestHelpers.RunProcess("dotnet", "run --project src/Zuke.Cli -- audit samples/import-source.law.txt");
-        Assert.Equal(0, audit.ExitCode);
+        var inputLaw = Path.Combine(TestHelpers.RepoRoot, "samples", "import-source.law.txt");
+        var inputMd = Path.Combine(TestHelpers.RepoRoot, "samples", "work-rules.md");
+        var audit = TestHelpers.RunZuke($"audit {TestHelpers.QuoteArg(inputLaw)}");
+        TestHelpers.AssertExitCode(audit, 0);
 
-        var import = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- import samples/import-source.law.txt -o {md}");
-        Assert.Equal(0, import.ExitCode);
+        var import = TestHelpers.RunZuke($"import {TestHelpers.QuoteArg(inputLaw)} -o {TestHelpers.QuoteArg(md)}");
+        TestHelpers.AssertExitCode(import, 0);
 
-        var convert = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- convert {md} --to both --xml-output {xml} --lawtext-output {law}");
-        Assert.Equal(0, convert.ExitCode);
+        var convert = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(md)} --to both --xml-output {TestHelpers.QuoteArg(xml)} --lawtext-output {TestHelpers.QuoteArg(law)}");
+        TestHelpers.AssertExitCode(convert, 0);
         var lawtext = File.ReadAllText(law);
         Assert.DoesNotContain("{{参照:", lawtext);
         Assert.DoesNotContain("🍣", lawtext);
 
         File.AppendAllText(md, "\n### （追加条） [条:追加条]\n追加本文\n");
-        var diff = TestHelpers.RunProcess("dotnet", $"run --project src/Zuke.Cli -- diff samples/work-rules.md {md}");
+        var diff = TestHelpers.RunZuke($"diff {TestHelpers.QuoteArg(inputMd)} {TestHelpers.QuoteArg(md)}");
         Assert.NotEqual(0, diff.ExitCode);
     }
 }

--- a/tests/Zuke.Core.Tests/TestHelpers.cs
+++ b/tests/Zuke.Core.Tests/TestHelpers.cs
@@ -43,10 +43,11 @@ public static class TestHelpers
             WorkingDirectory = workdir ?? RepoRoot
         };
         using var process = Process.Start(psi) ?? throw new InvalidOperationException($"failed to start {fileName}");
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
         process.WaitForExit();
-        return (process.ExitCode, stdout, stderr);
+        Task.WaitAll(stdoutTask, stderrTask);
+        return (process.ExitCode, stdoutTask.Result, stderrTask.Result);
     }
 
     public static (int ExitCode, string StdOut, string StdErr) RunZuke(string zukeArgs)

--- a/tests/Zuke.Core.Tests/TestHelpers.cs
+++ b/tests/Zuke.Core.Tests/TestHelpers.cs
@@ -10,6 +10,8 @@ public static class TestHelpers
 {
     public static string RepoRoot { get; } = ResolveRepoRoot();
     public static string CliProjectPath { get; } = Path.Combine(RepoRoot, "src", "Zuke.Cli", "Zuke.Cli.csproj");
+    private static bool _cliBuilt;
+    private static readonly object CliBuildLock = new();
 
     public static CompileResult Compile(string? markdown = null, bool strict = false, bool arabicNumbers = false)
     {
@@ -51,7 +53,10 @@ public static class TestHelpers
     }
 
     public static (int ExitCode, string StdOut, string StdErr) RunZuke(string zukeArgs)
-        => RunProcess("dotnet", $"run --project {QuoteArg(CliProjectPath)} -- {zukeArgs}", RepoRoot);
+    {
+        EnsureCliBuilt();
+        return RunProcess("dotnet", $"run --no-build -c Release --project {QuoteArg(CliProjectPath)} -- {zukeArgs}", RepoRoot);
+    }
 
     public static void AssertExitCode((int ExitCode, string StdOut, string StdErr) result, int expected)
     {
@@ -83,5 +88,17 @@ public static class TestHelpers
         }
 
         throw new InvalidOperationException("repo root not found");
+    }
+
+    private static void EnsureCliBuilt()
+    {
+        if (_cliBuilt) return;
+        lock (CliBuildLock)
+        {
+            if (_cliBuilt) return;
+            var build = RunProcess("dotnet", $"build {QuoteArg(CliProjectPath)} -c Release", RepoRoot);
+            AssertExitCode(build, 0);
+            _cliBuilt = true;
+        }
     }
 }

--- a/tests/Zuke.Core.Tests/TestHelpers.cs
+++ b/tests/Zuke.Core.Tests/TestHelpers.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Xunit;
 using Zuke.Core.Compilation;
 using Zuke.Core.Rendering;
 
@@ -8,6 +9,7 @@ namespace Zuke.Core.Tests;
 public static class TestHelpers
 {
     public static string RepoRoot { get; } = ResolveRepoRoot();
+    public static string CliProjectPath { get; } = Path.Combine(RepoRoot, "src", "Zuke.Cli", "Zuke.Cli.csproj");
 
     public static CompileResult Compile(string? markdown = null, bool strict = false, bool arabicNumbers = false)
     {
@@ -29,6 +31,9 @@ public static class TestHelpers
         return new LawtextRenderer().Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = arabicNumbers });
     }
 
+    public static string QuoteArg(string value)
+        => "\"" + value.Replace("\"", "\\\"") + "\"";
+
     public static (int ExitCode, string StdOut, string StdErr) RunProcess(string fileName, string args, string? workdir = null)
     {
         var psi = new ProcessStartInfo(fileName, args)
@@ -42,6 +47,25 @@ public static class TestHelpers
         var stderr = process.StandardError.ReadToEnd();
         process.WaitForExit();
         return (process.ExitCode, stdout, stderr);
+    }
+
+    public static (int ExitCode, string StdOut, string StdErr) RunZuke(string zukeArgs)
+        => RunProcess("dotnet", $"run --project {QuoteArg(CliProjectPath)} -- {zukeArgs}", RepoRoot);
+
+    public static void AssertExitCode((int ExitCode, string StdOut, string StdErr) result, int expected)
+    {
+        Assert.True(
+            result.ExitCode == expected,
+            $"""
+            Expected exit code: {expected}
+            Actual exit code: {result.ExitCode}
+
+            StdOut:
+            {result.StdOut}
+
+            StdErr:
+            {result.StdErr}
+            """);
     }
 
     private static string ResolveRepoRoot()


### PR DESCRIPTION
### Motivation

- Fix incorrect detection of branch-numbered articles by robustly extracting and validating the article token before parsing. 
- Simplify and standardize CLI integration tests so they run the same `dotnet run` invocation consistently and produce clearer test failure output.

### Description

- Add `BranchArticleTokenRegex` and update `LawtextAuditService.Audit` to extract the leading article token and validate it via `Numbering.ArticleNumberFormatter.TryParseArticleNumber`, improving LMD101 detection logic. 
- Add new unit test `Audit_BranchArticleValidation_Works` to cover valid and invalid branch-article forms. 
- Replace ad-hoc process invocations in multiple CLI integration tests with `TestHelpers.RunZuke` and use `TestHelpers.QuoteArg` for proper argument quoting. 
- Extend `TestHelpers` with `CliProjectPath`, `QuoteArg`, `RunZuke`, and `AssertExitCode` helpers, and add `Xunit` import to the helpers file.

### Testing

- Ran the test suite for `Zuke.Core.Tests` via the project test runner, exercising updated and new tests including `Audit_BranchArticleValidation_Works`. All tests passed. 
- Confirmed CLI integration tests now invoke the CLI via `RunZuke` and report non-zero/zero exit codes using `AssertExitCode` where expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18c4499888328ab8296db1232c9d0)