### PR TITLE
出力形式別メタデータ要件と internal-rule プロファイル対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ zuke audit input.law.txt
 - import後Markdownは再コンパイル・再レンダリング検証されます。
 - `--skip-roundtrip-check` は非推奨です。
 
+
+## メタデータ要件（出力別）
+
+- 社内規程・就業規則には、正式な法令番号が存在しない場合があります。
+- Lawtext出力では `lawTitle` のみ必須です。`lawNum` が空の場合、Lawtext冒頭の法令番号行は出力されません。
+- XML出力では法令標準XMLの都合上、`lawTitle/lawNum/era/year/num/lawType/lang` が必要です。
+- 社内規程をXML化する場合は `--metadata-profile internal-rule` を使うと不足値を補完できます。
+- `lawNum: none` より、`lawNum: 社内規程` もしくは `--metadata-profile internal-rule` の利用を推奨します。
+
+### --metadata-profile
+
+`zuke convert` は以下のプロファイルをサポートします。
+
+- `--metadata-profile default`（既定）
+  - 従来どおり。XML出力時は完全なメタデータを要求します。
+- `--metadata-profile internal-rule`
+  - 社内規程向け。不足メタデータを次で補完します。
+  - `lawNum: 社内規程`, `era: Reiwa`, `year: 1`, `num: 1`, `lawType: Misc`, `lang: ja`
+  - `lawTitle` は補完しません（必須）。
+
 ## XMLとLawtextの同時出力
 
 ```bash

--- a/src/Zuke.Cli/Commands/ConvertCommand.cs
+++ b/src/Zuke.Cli/Commands/ConvertCommand.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using Zuke.Cli.Console;
 using Zuke.Core.Compilation;
+using Zuke.Core.Markdown;
 using Zuke.Core.Rendering;
 using Zuke.Core.Validation;
 
@@ -23,6 +24,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         [CommandOption("--emoji <MODE>")] public string Emoji { get; set; } = "auto";
         [CommandOption("--no-color")] public bool NoColor { get; set; }
         [CommandOption("--plain")] public bool Plain { get; set; }
+        [CommandOption("--metadata-profile <PROFILE>")] public string MetadataProfile { get; set; } = "default";
     }
 
     public override int Execute(CommandContext context, Settings settings)
@@ -46,7 +48,11 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
             var renderDiags = LawtextRenderer.ValidateRenderedText(lawtext);
             reporter.ReportDiagnostics(renderDiags);
             if (renderDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
-            var docBoth = new LawXmlRenderer().Render(result.Document.Document, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+            var xmlModelBoth = ApplyMetadataProfile(result.Document.Document, settings.MetadataProfile);
+            var xmlMetaDiagsBoth = FrontMatterParser.ValidateForXml(xmlModelBoth.Metadata, settings.Input);
+            reporter.ReportDiagnostics(xmlMetaDiagsBoth);
+            if (xmlMetaDiagsBoth.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
+            var docBoth = new LawXmlRenderer().Render(xmlModelBoth, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
             if (!settings.SkipValidation)
             {
                 var xsd = settings.Xsd ?? ZukeXsdProvider.ResolveDefaultPath();
@@ -72,7 +78,11 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
             return 0;
         }
 
-        var doc = new LawXmlRenderer().Render(result.Document.Document, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+        var xmlModel = ApplyMetadataProfile(result.Document.Document, settings.MetadataProfile);
+        var xmlMetaDiags = FrontMatterParser.ValidateForXml(xmlModel.Metadata, settings.Input);
+        reporter.ReportDiagnostics(xmlMetaDiags);
+        if (xmlMetaDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
+        var doc = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
         if (!settings.SkipValidation)
         {
             var xsd = settings.Xsd ?? ZukeXsdProvider.ResolveDefaultPath();
@@ -83,5 +93,21 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         doc.Save(settings.Output);
         reporter.Info($"法令XMLを出力しました: {settings.Output}");
         return 0;
+    }
+
+    private static Zuke.Core.Model.LawDocumentModel ApplyMetadataProfile(Zuke.Core.Model.LawDocumentModel model, string profile)
+    {
+        if (!string.Equals(profile, "internal-rule", StringComparison.OrdinalIgnoreCase)) return model;
+        var m = model.Metadata;
+        var normalized = m with
+        {
+            LawNum = string.IsNullOrWhiteSpace(m.LawNum) ? "社内規程" : m.LawNum,
+            Era = string.IsNullOrWhiteSpace(m.Era) ? "Reiwa" : m.Era,
+            Year = m.Year <= 0 ? 1 : m.Year,
+            Num = m.Num <= 0 ? 1 : m.Num,
+            LawType = string.IsNullOrWhiteSpace(m.LawType) ? "Misc" : m.LawType,
+            Lang = string.IsNullOrWhiteSpace(m.Lang) ? "ja" : m.Lang
+        };
+        return model with { Metadata = normalized };
     }
 }

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -192,8 +192,8 @@ public sealed class LawtextParser
     private static LawMetadata InferMetadata(string lawTitle, string lawNum, string? filePath, List<DiagnosticMessage> diags)
     {
         var era = "Reiwa";
-        var year = 0;
-        var num = 0;
+        var year = 1;
+        var num = 1;
         var lawType = "Misc";
         var m = Regex.Match(lawNum, @"^(?<era>令和|平成|昭和)(?<y>[一二三四五六七八九十百千0-9０-９]+)年(?<type>法律|規則)第(?<n>[一二三四五六七八九十百千0-9０-９]+)号$");
         if (m.Success)
@@ -203,7 +203,11 @@ public sealed class LawtextParser
             num = ParseNumber(m.Groups["n"].Value);
             lawType = m.Groups["type"].Value == "法律" ? "Act" : "Misc";
         }
-        else if (!string.IsNullOrWhiteSpace(lawNum))
+        else if (string.IsNullOrWhiteSpace(lawNum))
+        {
+            diags.Add(new(DiagnosticSeverity.Warning, "LMD090", "LawNum がありません。社内規程として扱います。", new(filePath, 1, 1), []));
+        }
+        else
         {
             diags.Add(new(DiagnosticSeverity.Warning, "LMD090", "Lawtextの法令番号からメタデータを完全には推定できません。", new(filePath, 1, 1), []));
         }

--- a/src/Zuke.Core/Markdown/FrontMatterParser.cs
+++ b/src/Zuke.Core/Markdown/FrontMatterParser.cs
@@ -39,8 +39,8 @@ public static class FrontMatterParser
                 map.TryGetValue("lawTitle", out var a) ? a.ToString() ?? "" : "",
                 map.TryGetValue("lawNum", out var b) ? b.ToString() ?? "" : "",
                 map.TryGetValue("era", out var c) ? c.ToString() ?? "" : "",
-                map.TryGetValue("year", out var d) ? Convert.ToInt32(d) : 0,
-                map.TryGetValue("num", out var e) ? Convert.ToInt32(e) : 0,
+                map.TryGetValue("year", out var d) ? Convert.ToInt32(d) : 1,
+                map.TryGetValue("num", out var e) ? Convert.ToInt32(e) : 1,
                 map.TryGetValue("lawType", out var f) ? f.ToString() ?? "" : "",
                 map.TryGetValue("lang", out var g) ? g.ToString() ?? "" : "");
 
@@ -68,7 +68,21 @@ public static class FrontMatterParser
         return [new(DiagnosticSeverity.Error, "LMD045", msg, new SourceLocation(filePath, 1, 1), [])];
     }
 
-    private static readonly string[] RequiredKeys = ["lawTitle", "lawNum", "era", "year", "num", "lawType", "lang"];
+    private static readonly string[] RequiredKeys = ["lawTitle"];
+
+    public static IReadOnlyList<DiagnosticMessage> ValidateForXml(LawMetadata metadata, string? filePath)
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(metadata.LawTitle)) missing.Add("lawTitle");
+        if (string.IsNullOrWhiteSpace(metadata.LawNum)) missing.Add("lawNum");
+        if (string.IsNullOrWhiteSpace(metadata.Era)) missing.Add("era");
+        if (metadata.Year <= 0) missing.Add("year");
+        if (metadata.Num <= 0) missing.Add("num");
+        if (string.IsNullOrWhiteSpace(metadata.LawType)) missing.Add("lawType");
+        if (string.IsNullOrWhiteSpace(metadata.Lang)) missing.Add("lang");
+        if (missing.Count == 0) return [];
+        return [new(DiagnosticSeverity.Error, "LMD045", $"必須メタデータが不足しています: {string.Join(", ", missing)}", new SourceLocation(filePath, 1, 1), [])];
+    }
 
     private static LawMetadata DefaultMetadata() => new("無題", "", "Reiwa", 1, 1, "Misc", "ja");
 }

--- a/tests/Zuke.Core.Tests/MetadataProfileBehaviorTests.cs
+++ b/tests/Zuke.Core.Tests/MetadataProfileBehaviorTests.cs
@@ -1,0 +1,59 @@
+using Zuke.Core.References;
+using Zuke.Core.Importing;
+using Zuke.Core.Markdown;
+using Zuke.Core.Model;
+using Zuke.Core.Rendering;
+using Xunit;
+
+namespace Zuke.Core.Tests;
+
+public class LawtextAllowsMissingLawNumTests
+{
+    [Fact]
+    public void FrontMatterWithLawTitleOnly_CanRenderLawtext()
+    {
+        var md = "---\nlawTitle: 育児・介護休業等に関する規則\n---\n\n## 目的\n本文\n";
+        var r = TestHelpers.Compile(md);
+        Assert.DoesNotContain(r.Diagnostics, d => d.Code == "LMD045");
+        var lawtext = new LawtextRenderer().Render(r.Document!, LawtextRenderOptions.Default);
+        Assert.DoesNotContain("（", lawtext.Split('\n').Take(2));
+    }
+
+    [Fact]
+    public void LawNumEmpty_DoesNotRenderLawNumLine()
+    {
+        var model = new LawDocumentModel(new LawMetadata("T", "", "Reiwa", 1, 1, "Misc", "ja"), [], [], []);
+        var text = new LawtextRenderer().Render(new CompiledLawDocument(model, new Dictionary<string, ReferenceDefinition>(), []), LawtextRenderOptions.Default);
+        var lines = text.Split('\n', StringSplitOptions.None);
+        Assert.Equal("T", lines[0]);
+        Assert.DoesNotContain(lines, l => l.StartsWith("（") && l.EndsWith("）"));
+    }
+}
+
+public class XmlRequiresMetadataTests
+{
+    [Theory]
+    [InlineData("", "N", "Reiwa", 1, 1, "Misc", "ja")]
+    [InlineData("T", "", "Reiwa", 1, 1, "Misc", "ja")]
+    [InlineData("T", "N", "", 1, 1, "Misc", "ja")]
+    [InlineData("T", "N", "Reiwa", 0, 1, "Misc", "ja")]
+    [InlineData("T", "N", "Reiwa", 1, 0, "Misc", "ja")]
+    public void MissingOrInvalidMetadata_IsLmd045(string t, string n, string e, int y, int num, string lt, string lang)
+    {
+        var diags = FrontMatterParser.ValidateForXml(new LawMetadata(t, n, e, y, num, lt, lang), "x.md");
+        Assert.Contains(diags, d => d.Code == "LMD045");
+    }
+}
+
+public class ImportWithoutLawNumTests
+{
+    [Fact]
+    public void MissingLawNum_ImportsWithDefaultsAndWarning()
+    {
+        var src = "育児・介護休業等に関する規則\n\n第一章　目的\n第一条　目的本文\n";
+        var (model, diags) = new LawtextParser().Parse(src, "in.law.txt");
+        Assert.Equal(1, model.Metadata.Year);
+        Assert.Equal(1, model.Metadata.Num);
+        Assert.Contains(diags, d => d.Code == "LMD090" && d.Message.Contains("LawNum がありません"));
+    }
+}


### PR DESCRIPTION
### Motivation

- 社内規程や就業規則など法令番号を持たない文書を Lawtext / Markdown ワークフローで扱えるように、Front Matter の必須要件を緩和しつつ、法令標準XML出力では厳密なメタデータ検証を維持する必要があった。 
- 社内規程を XML 化する際に既定値で補完できる `internal-rule` プロファイルを CLI に追加して運用の柔軟性を確保する。

### Description

- `FrontMatterParser` の必須キーをコンパイル共通では `lawTitle` のみに変更し、`year`/`num` の既定値を `1` に変更した。なお XML 用の厳格検証を行う `ValidateForXml(...)` を追加して、XML 出力時に必要な `lawTitle/lawNum/era/year/num/lawType/lang` をチェックするように分離した。 (`src/Zuke.Core/Markdown/FrontMatterParser.cs`)
- `convert` コマンドに `--metadata-profile <PROFILE>` を追加し、`default|internal-rule` を選べるようにした。`--to xml`/`--to both` の際は `ValidateForXml` を実行し、`internal-rule` 指定時は不足メタデータを `lawNum=社内規程, era=Reiwa, year=1, num=1, lawType=Misc, lang=ja` で補完するようにした。 (`src/Zuke.Cli/Commands/ConvertCommand.cs`)
- Lawtext の import ロジックで法令番号行がない場合に `LMD090: LawNum がありません。社内規程として扱います。` を出すようにし、推定不能でも `year`/`num` は `1` で扱うように変更した。 (`src/Zuke.Core/Importing/LawtextParser.cs`)
- Lawtext / XML の振る舞いを明示する説明を `README.md` に追記した。 (`README.md`)
- 振る舞いを検証する自動テストを追加した（LawtextAllow..., XmlRequires..., ImportWithout... の各テスト）。 (`tests/Zuke.Core.Tests/MetadataProfileBehaviorTests.cs`)

### Testing

- 実行した自動テスト: `dotnet test --nologo` を実行し、テストスイートは成功して全テストが通過した（Passed 162 / Failed 0）。
- 追加したユニットテストで、lawTitle のみで Lawtext 出力可能・lawNum 空時に法令番号行を出さない・XML 側の必須チェックで `LMD045` が出る・Lawtext import 時に `LMD090` と `year/num=1` が出ることを検証している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21b220b948328a35504791f9ea737)