### PR TITLE
Allow lawtext conversion without Front Matter metadata

### DIFF
--- a/src/Zuke.Cli/Commands/ConvertCommand.cs
+++ b/src/Zuke.Cli/Commands/ConvertCommand.cs
@@ -32,7 +32,9 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         var consoleOptions = ConsoleOptions.From(settings.Plain, settings.Emoji, settings.NoColor);
         var reporter = new ConsoleReporter(AnsiConsole.Console, consoleOptions);
         var text = File.ReadAllText(settings.Input);
-        var result = new LawMarkdownCompiler().Compile(text, settings.Input, new CompileOptions(settings.Strict, settings.NumberStyle == "arabic"));
+        var frontMatter = FrontMatterParser.ParseDetailed(text);
+        var requireFrontMatter = !string.Equals(settings.To, "lawtext", StringComparison.OrdinalIgnoreCase);
+        var result = new LawMarkdownCompiler().Compile(text, settings.Input, new CompileOptions(settings.Strict, settings.NumberStyle == "arabic", requireFrontMatter));
         reporter.ReportDiagnostics(result.Diagnostics);
         if (result.HasErrors || result.Document is null) return 1;
 
@@ -67,8 +69,9 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
 
         if (settings.To == "lawtext")
         {
+            var lawtextModel = ApplyLawtextMetadataFallback(result.Document.Document, frontMatter, settings.Input);
             var renderer = new LawtextRenderer();
-            var lawtext = renderer.Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+            var lawtext = renderer.Render(result.Document with { Document = lawtextModel }, LawtextRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
             var renderDiags = LawtextRenderer.ValidateRenderedText(lawtext);
             reporter.ReportDiagnostics(renderDiags);
             if (renderDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
@@ -93,6 +96,35 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         doc.Save(settings.Output);
         reporter.Info($"法令XMLを出力しました: {settings.Output}");
         return 0;
+    }
+
+    private static Zuke.Core.Model.LawDocumentModel ApplyLawtextMetadataFallback(Zuke.Core.Model.LawDocumentModel model, FrontMatterParseResult frontMatter, string inputPath)
+    {
+        if (frontMatter.HasFrontMatter) return model;
+        var inferredTitle = InferLawTitle(model, inputPath);
+        return model with
+        {
+            Metadata = model.Metadata with
+            {
+                LawTitle = inferredTitle
+            }
+        };
+    }
+
+    private static string InferLawTitle(Zuke.Core.Model.LawDocumentModel model, string inputPath)
+    {
+        if (model.Chapters.Count > 0 && !string.IsNullOrWhiteSpace(model.Chapters[0].Title))
+        {
+            return model.Chapters[0].Title.Trim();
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(inputPath);
+        if (!string.IsNullOrWhiteSpace(fileName))
+        {
+            return fileName.Trim();
+        }
+
+        return "無題";
     }
 
     private static Zuke.Core.Model.LawDocumentModel ApplyMetadataProfile(Zuke.Core.Model.LawDocumentModel model, string profile)

--- a/src/Zuke.Core/Compilation/CompileOptions.cs
+++ b/src/Zuke.Core/Compilation/CompileOptions.cs
@@ -1,1 +1,1 @@
-namespace Zuke.Core.Compilation; public sealed record CompileOptions(bool Strict=false,bool ArabicNumbers=false);
+namespace Zuke.Core.Compilation; public sealed record CompileOptions(bool Strict=false,bool ArabicNumbers=false, bool RequireFrontMatter=true);

--- a/src/Zuke.Core/Compilation/LawMarkdownCompiler.cs
+++ b/src/Zuke.Core/Compilation/LawMarkdownCompiler.cs
@@ -14,7 +14,10 @@ public sealed class LawMarkdownCompiler
         var fm = FrontMatterParser.ParseDetailed(markdown);
         var model = new MarkdownLawParser().Parse(markdown, filePath);
         var diags = new List<DiagnosticMessage>(model.Diagnostics);
-        diags.AddRange(FrontMatterParser.ValidateRequired(fm, filePath));
+        if (options.RequireFrontMatter)
+        {
+            diags.AddRange(FrontMatterParser.ValidateRequired(fm, filePath));
+        }
         diags.AddRange(new LawStructureValidator().Validate(model));
         foreach (var article in EnumerateArticles(model))
         {

--- a/tests/Zuke.Core.Tests/LawtextCliIntegrationTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextCliIntegrationTests.cs
@@ -44,4 +44,32 @@ public class LawtextCliIntegrationTests
         TestHelpers.AssertExitCode(run, 1);
         Assert.Contains("+", run.StdOut);
     }
+
+    [Fact]
+    public void ConvertToLawtext_AllowsMissingFrontMatter_AndUsesFirstHeadingAsTitle()
+    {
+        var input = Path.GetTempFileName();
+        var output = Path.GetTempFileName();
+        File.WriteAllText(input, "# 育児・介護休業等に関する規則\n\n## 目的\n本文\n");
+
+        var run = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(output)} --to lawtext");
+        TestHelpers.AssertExitCode(run, 0);
+        var text = File.ReadAllText(output, Encoding.UTF8);
+        Assert.StartsWith("育児・介護休業等に関する規則", text);
+    }
+
+    [Fact]
+    public void ConvertToLawtext_WithoutHeading_UsesFileNameAsTitle()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"zuke-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var input = Path.Combine(dir, "社内規程案.md");
+        var output = Path.GetTempFileName();
+        File.WriteAllText(input, "## 目的\n本文\n");
+
+        var run = TestHelpers.RunZuke($"convert {TestHelpers.QuoteArg(input)} -o {TestHelpers.QuoteArg(output)} --to lawtext");
+        TestHelpers.AssertExitCode(run, 0);
+        var text = File.ReadAllText(output, Encoding.UTF8);
+        Assert.StartsWith("社内規程案", text);
+    }
 }


### PR DESCRIPTION
### Motivation

- Allow `convert --to lawtext` to produce lawtext for documents that lack YAML Front Matter so internal rules and manually authored extended Markdown can be processed without raising `LMD045`.
- Provide a sensible `lawTitle` when Front Matter is missing by inferring it from document structure or file name to match Lawtext output expectations.

### Description

- Add `RequireFrontMatter` to `CompileOptions` and make `LawMarkdownCompiler` only enforce `FrontMatterParser.ValidateRequired` when `RequireFrontMatter` is true (files: `src/Zuke.Core/Compilation/CompileOptions.cs`, `src/Zuke.Core/Compilation/LawMarkdownCompiler.cs`).
- Update `ConvertCommand` to set `RequireFrontMatter=false` when `--to lawtext`, parse front matter early, and apply a Lawtext-only metadata fallback that sets `lawTitle` from the first `#` heading, then file name, then `"無題"` (file: `src/Zuke.Cli/Commands/ConvertCommand.cs`).
- Implement `ApplyLawtextMetadataFallback` and `InferLawTitle` helpers and render lawtext using the adjusted model when Front Matter is absent (file: `src/Zuke.Cli/Commands/ConvertCommand.cs`).
- Add CLI integration tests to cover missing Front Matter cases and the title inference behavior (file: `tests/Zuke.Core.Tests/LawtextCliIntegrationTests.cs`).

### Testing

- Ran `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter "LawtextCliIntegrationTests|FrontMatterTests|LawtextAllowsMissingLawNumTests"` and it passed with `Passed: 8, Failed: 0, Skipped: 0`.
- Existing XML metadata validation is unchanged and still enforced for `--to xml` and `--to both` via `FrontMatterParser.ValidateForXml` as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22ddec8c08328a711df625d802bf9)