### PR TITLE
Preserve `lawTitle` when front matter parsing fails; handle BOM and malformed YAML

### DIFF
--- a/src/Zuke.Core/Markdown/FrontMatterParser.cs
+++ b/src/Zuke.Core/Markdown/FrontMatterParser.cs
@@ -14,7 +14,7 @@ public static class FrontMatterParser
 
     public static FrontMatterParseResult ParseDetailed(string markdown)
     {
-        var normalized = markdown.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var normalized = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).TrimStart('\uFEFF');
         if (!normalized.StartsWith("---\n", StringComparison.Ordinal))
         {
             return new FrontMatterParseResult(DefaultMetadata(), markdown, false, []);
@@ -48,8 +48,53 @@ public static class FrontMatterParser
         }
         catch
         {
-            return new FrontMatterParseResult(DefaultMetadata(), bodyNormalized, true, [.. RequiredKeys]);
+            var metadata = ParseBestEffortMetadata(yaml);
+            var missing = RequiredKeys.Where(k =>
+                k == "lawTitle" && string.IsNullOrWhiteSpace(metadata.LawTitle)).ToList();
+            return new FrontMatterParseResult(metadata, bodyNormalized, true, missing);
         }
+    }
+
+    private static LawMetadata ParseBestEffortMetadata(string yaml)
+    {
+        var fallback = DefaultMetadata();
+        var title = TryExtractScalar(yaml, "lawTitle") ?? fallback.LawTitle;
+        var lawNum = TryExtractScalar(yaml, "lawNum") ?? fallback.LawNum;
+        var era = TryExtractScalar(yaml, "era") ?? fallback.Era;
+        var lawType = TryExtractScalar(yaml, "lawType") ?? fallback.LawType;
+        var lang = TryExtractScalar(yaml, "lang") ?? fallback.Lang;
+        var year = int.TryParse(TryExtractScalar(yaml, "year"), out var parsedYear) ? parsedYear : fallback.Year;
+        var num = int.TryParse(TryExtractScalar(yaml, "num"), out var parsedNum) ? parsedNum : fallback.Num;
+
+        return new LawMetadata(title, lawNum, era, year, num, lawType, lang);
+    }
+
+    private static string? TryExtractScalar(string yaml, string key)
+    {
+        foreach (var rawLine in yaml.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#')) continue;
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex <= 0) continue;
+
+            var left = line[..separatorIndex].Trim();
+            if (!left.Equals(key, StringComparison.Ordinal)) continue;
+
+            var right = line[(separatorIndex + 1)..].Trim();
+            if (right.Length >= 2)
+            {
+                if ((right[0] == '"' && right[^1] == '"') || (right[0] == '\'' && right[^1] == '\''))
+                {
+                    right = right[1..^1];
+                }
+            }
+
+            return right;
+        }
+
+        return null;
     }
 
     public static IReadOnlyList<DiagnosticMessage> ValidateRequired(FrontMatterParseResult result, string? filePath)

--- a/tests/Zuke.Core.Tests/FrontMatterTests.cs
+++ b/tests/Zuke.Core.Tests/FrontMatterTests.cs
@@ -18,4 +18,35 @@ public class FrontMatterTests
         var r = TestHelpers.Compile(md);
         Assert.DoesNotContain(r.Diagnostics, d => d.Code == "LMD045");
     }
+
+    [Fact]
+    public void FrontMatterWithUtf8Bom_IsParsed()
+    {
+        var md = "\uFEFF" + """
+---
+lawTitle: 育児・介護休業等に関する規則
+---
+
+## 目的
+本文
+""";
+        var lawtext = TestHelpers.RenderLawtext(md);
+        Assert.StartsWith("育児・介護休業等に関する規則", lawtext);
+    }
+
+    [Fact]
+    public void MalformedFrontMatter_StillUsesLawTitleWhenPresent()
+    {
+        var md = """
+---
+lawTitle: 育児・介護休業等に関する規則
+num: [
+---
+
+## 目的
+本文
+""";
+        var lawtext = TestHelpers.RenderLawtext(md);
+        Assert.StartsWith("育児・介護休業等に関する規則", lawtext);
+    }
 }


### PR DESCRIPTION
### Motivation
- Markdown→Lawtext 変換で Front Matter の解析に失敗した際、`lawTitle` が存在しても既定値の「無題」に落ちてしまう問題を解消するための修正です。 
- UTF-8 BOM や部分的に壊れた YAML（例: `num: [`）が原因で `lawTitle` が失われるケースを防ぎます.

### Description
- `FrontMatterParser.ParseDetailed` で先頭の UTF-8 BOM を除去するようにして、BOM付きファイルでも `---` 判定が失敗しないようにしました (`TrimStart('\uFEFF')`)。 
- YAML パースが例外になる場合は `DefaultMetadata()` に即落とし込む代わりに、`ParseBestEffortMetadata` を用いて生の YAML 行から `lawTitle` 等のスカラーをベストエフォートで抽出するようにしました。 
- ベストエフォート抽出用の `TryExtractScalar` ヘルパーを追加し、簡単な `key: value` と引用符付き値への対応を実装しました。 
- YAML パース失敗時の必須キー判定は、抽出した `lawTitle` が空であれば欠落と見なすように変更しました。 
- 回帰防止のため、BOM 付き Front Matter と壊れた Front Matter からでも `lawTitle` が Lawtext 先頭に反映されることを確認するテストを追加しました (`tests/Zuke.Core.Tests/FrontMatterTests.cs`)。

### Testing
- 実行した自動テスト: `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter FrontMatterTests` が最終的に成功し、該当テスト群はすべて通過しました（Passed: 4 / Failed: 0）。
- 追加したテストは次のケースを検証します: BOM付き Front Matter の解析、および壊れた YAML でも `lawTitle` を優先して表示すること。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2392a4d8c8328847dde8638bc7f3d)