### PR TITLE
Preserve Lawtext numbering/style and subitem structure during import round-trip

### DIFF
--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -22,6 +22,7 @@ public sealed class ExtendedMarkdownRenderer
             Append($"num: {model.Metadata.Num}");
             Append($"lawType: {model.Metadata.LawType}");
             Append($"lang: {model.Metadata.Lang}");
+            Append($"numberStyle: {model.Metadata.NumberStyle}");
             Append("---");
             Append("");
         }
@@ -46,7 +47,10 @@ public sealed class ExtendedMarkdownRenderer
         void RenderArticle(ArticleNode article)
         {
             var label = ShouldEmitLabel(article.ReferenceName, "Article") ? $" [条:{article.ReferenceName}]" : "";
-            Append($"### {(string.IsNullOrWhiteSpace(article.Caption) ? $"条 {article.ReferenceName}" : article.Caption)}{label}");
+            var articleTitle = article.ArticleNumber is null
+                ? BuildArticleNumber(article)
+                : $"第{article.ArticleNumber.BaseNumber}条{string.Concat(article.ArticleNumber.BranchNumbers.Select(b => $"の{b}"))}";
+            Append($"### {articleTitle}{(string.IsNullOrWhiteSpace(article.Caption) ? "" : $" {article.Caption}")}{label}");
             mapping.Add(CreateMapping("Article", article.Location?.Line, BuildArticleNumber(article), article.ReferenceName, article.Caption));
             Append("");
             foreach (var paragraph in article.Paragraphs) RenderParagraph(article, paragraph);

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -37,6 +37,7 @@ public sealed class LawtextParser
         }
 
         var metadata = InferMetadata(title, lawNum, filePath, diags);
+        var detectedArticleNumberStyle = "kanji";
 
         var chapters = new List<ChapterNode>();
         var direct = new List<ArticleNode>();
@@ -89,6 +90,10 @@ public sealed class LawtextParser
             {
                 FlushArticle();
                 var articleText = article.Groups["num"].Value;
+                if (detectedArticleNumberStyle == "kanji" && Regex.IsMatch(articleText, "[0-9０-９]"))
+                {
+                    detectedArticleNumberStyle = "arabic";
+                }
                 if (!ArticleNumberFormatter.TryParseArticleNumber(articleText, out var articleNumber))
                 {
                     diags.Add(new(DiagnosticSeverity.Warning, "LMD101", "Article枝番号の形式が不正です。", new(filePath, i + 1, 1), []));
@@ -140,7 +145,7 @@ public sealed class LawtextParser
         FlushSection();
         FlushChapter();
 
-        var model = new LawDocumentModel(metadata, chapters, direct, diags);
+        var model = new LawDocumentModel(metadata with { NumberStyle = detectedArticleNumberStyle }, chapters, direct, diags);
         return (model, diags);
 
         void FlushParagraph()

--- a/src/Zuke.Core/Markdown/FrontMatterParser.cs
+++ b/src/Zuke.Core/Markdown/FrontMatterParser.cs
@@ -42,7 +42,10 @@ public static class FrontMatterParser
                 map.TryGetValue("year", out var d) ? Convert.ToInt32(d) : 1,
                 map.TryGetValue("num", out var e) ? Convert.ToInt32(e) : 1,
                 map.TryGetValue("lawType", out var f) ? f.ToString() ?? "" : "",
-                map.TryGetValue("lang", out var g) ? g.ToString() ?? "" : "");
+                map.TryGetValue("lang", out var g) ? g.ToString() ?? "" : "")
+            {
+                NumberStyle = map.TryGetValue("numberStyle", out var h) ? h?.ToString() ?? "kanji" : "kanji"
+            };
 
             return new FrontMatterParseResult(metadata, bodyNormalized, true, missing);
         }
@@ -66,7 +69,10 @@ public static class FrontMatterParser
         var year = int.TryParse(TryExtractScalar(yaml, "year"), out var parsedYear) ? parsedYear : fallback.Year;
         var num = int.TryParse(TryExtractScalar(yaml, "num"), out var parsedNum) ? parsedNum : fallback.Num;
 
-        return new LawMetadata(title, lawNum, era, year, num, lawType, lang);
+        return new LawMetadata(title, lawNum, era, year, num, lawType, lang)
+        {
+            NumberStyle = TryExtractScalar(yaml, "numberStyle") ?? fallback.NumberStyle
+        };
     }
 
     private static string? TryExtractScalar(string yaml, string key)

--- a/src/Zuke.Core/Model/LawMetadata.cs
+++ b/src/Zuke.Core/Model/LawMetadata.cs
@@ -1,2 +1,5 @@
 namespace Zuke.Core.Model;
-public sealed record LawMetadata(string LawTitle,string LawNum,string Era,int Year,int Num,string LawType,string Lang);
+public sealed record LawMetadata(string LawTitle,string LawNum,string Era,int Year,int Num,string LawType,string Lang)
+{
+    public string NumberStyle { get; init; } = "kanji";
+}

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -283,6 +283,15 @@ public sealed class MarkdownLawParser
             return true;
         }
 
+        var bulletSubitem = Regex.Match(text, @"^(?:[-*]|・)\s*(?<title>[イロハニホヘトチリヌルヲワカヨタレソツネナラムウヰノオクヤマケフコエテアサキユメミシヱヒモセス])\s*[　 ](?<text>.+)$");
+        if (bulletSubitem.Success)
+        {
+            title = bulletSubitem.Groups["title"].Value;
+            sentence = bulletSubitem.Groups["text"].Value.Trim();
+            isSubitem1 = true;
+            return true;
+        }
+
         var bullet = Regex.Match(text, @"^(?:[-*]|・)\s*(?<text>.+)$");
         if (bullet.Success)
         {


### PR DESCRIPTION
### Motivation
- The Lawtext → Markdown → Lawtext round-trip was losing structural fidelity such as branch article numbers (e.g. `第9条の2` collapsing), numeral style changes (`第1条` → `第一条`), and flattening of subitems, which breaks references and document identity.

### Description
- Add `NumberStyle` to `LawMetadata` (default `"kanji"`) and make `FrontMatterParser` parse and best-effort extract `numberStyle` from YAML front matter.
- Detect the article numbering style during Lawtext import in `LawtextParser` and store the detected style in document metadata as `numberStyle`.
- Emit `numberStyle` into generated front matter and render article headings with explicit Lawtext article numbers (including branch numbers like `の2`) in `ExtendedMarkdownRenderer` to prevent numbering collapse on recompile.
- Adjust `MarkdownLawParser` item parsing to recognize bullet subitems like `- イ ...` as subitems first so `イ・ロ・ハ` hierarchies are preserved.

### Testing
- Ran the targeted test selection with `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter "FullyQualifiedName~LawtextImportRoundTripTests|FullyQualifiedName~BranchArticleReferenceTests|FullyQualifiedName~LawtextImportMarkdownRendererTests|FullyQualifiedName~MarkdownListParsingTests|FullyQualifiedName~FrontMatterTests"` and all selected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23ea8ae508328b642658cd7f0eb10)