### PR TITLE
Fix Lawtext round-trip regressions: numberStyle fallback, composite refs, multiline & supplementary provision

### DIFF
--- a/src/Zuke.Cli/Commands/ConvertCommand.cs
+++ b/src/Zuke.Cli/Commands/ConvertCommand.cs
@@ -20,7 +20,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         [CommandOption("--strict")] public bool Strict { get; set; }
         [CommandOption("--xml-output <PATH>")] public string? XmlOutput { get; set; }
         [CommandOption("--lawtext-output <PATH>")] public string? LawtextOutput { get; set; }
-        [CommandOption("--number-style <STYLE>")] public string NumberStyle { get; set; } = "kanji";
+        [CommandOption("--number-style <STYLE>")] public string NumberStyle { get; set; } = "auto";
         [CommandOption("--emoji <MODE>")] public string Emoji { get; set; } = "auto";
         [CommandOption("--no-color")] public bool NoColor { get; set; }
         [CommandOption("--plain")] public bool Plain { get; set; }
@@ -34,7 +34,8 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         var text = File.ReadAllText(settings.Input);
         var frontMatter = FrontMatterParser.ParseDetailed(text);
         var requireFrontMatter = !string.Equals(settings.To, "lawtext", StringComparison.OrdinalIgnoreCase);
-        var result = new LawMarkdownCompiler().Compile(text, settings.Input, new CompileOptions(settings.Strict, settings.NumberStyle == "arabic", requireFrontMatter));
+        var resolvedNumberStyle = ResolveNumberStyle(settings.NumberStyle, frontMatter);
+        var result = new LawMarkdownCompiler().Compile(text, settings.Input, new CompileOptions(settings.Strict, resolvedNumberStyle == "arabic", requireFrontMatter));
         reporter.ReportDiagnostics(result.Diagnostics);
         if (result.HasErrors || result.Document is null) return 1;
 
@@ -46,7 +47,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
                 reporter.Info("--to both では --xml-output と --lawtext-output が必須で、-o は使用できません。");
                 return 1;
             }
-            var lawtext = new LawtextRenderer().Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+            var lawtext = new LawtextRenderer().Render(result.Document, LawtextRenderOptions.Default with { ArabicNumbers = resolvedNumberStyle == "arabic" });
             var renderDiags = LawtextRenderer.ValidateRenderedText(lawtext);
             reporter.ReportDiagnostics(renderDiags);
             if (renderDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
@@ -54,7 +55,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
             var xmlMetaDiagsBoth = FrontMatterParser.ValidateForXml(xmlModelBoth.Metadata, settings.Input);
             reporter.ReportDiagnostics(xmlMetaDiagsBoth);
             if (xmlMetaDiagsBoth.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
-            var docBoth = new LawXmlRenderer().Render(xmlModelBoth, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+            var docBoth = new LawXmlRenderer().Render(xmlModelBoth, LawXmlRenderOptions.Default with { ArabicNumbers = resolvedNumberStyle == "arabic" });
             if (!settings.SkipValidation)
             {
                 var xsd = settings.Xsd ?? ZukeXsdProvider.ResolveDefaultPath();
@@ -71,7 +72,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         {
             var lawtextModel = ApplyLawtextMetadataFallback(result.Document.Document, frontMatter, settings.Input);
             var renderer = new LawtextRenderer();
-            var lawtext = renderer.Render(result.Document with { Document = lawtextModel }, LawtextRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+            var lawtext = renderer.Render(result.Document with { Document = lawtextModel }, LawtextRenderOptions.Default with { ArabicNumbers = resolvedNumberStyle == "arabic" });
             var renderDiags = LawtextRenderer.ValidateRenderedText(lawtext);
             reporter.ReportDiagnostics(renderDiags);
             if (renderDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
@@ -85,7 +86,7 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
         var xmlMetaDiags = FrontMatterParser.ValidateForXml(xmlModel.Metadata, settings.Input);
         reporter.ReportDiagnostics(xmlMetaDiags);
         if (xmlMetaDiags.Any(x => x.Severity == Zuke.Core.Model.DiagnosticSeverity.Error)) return 1;
-        var doc = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = settings.NumberStyle == "arabic" });
+        var doc = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = resolvedNumberStyle == "arabic" });
         if (!settings.SkipValidation)
         {
             var xsd = settings.Xsd ?? ZukeXsdProvider.ResolveDefaultPath();
@@ -109,6 +110,14 @@ public sealed class ConvertCommand : Command<ConvertCommand.Settings>
                 LawTitle = inferredTitle
             }
         };
+    }
+
+    private static string ResolveNumberStyle(string cliValue, FrontMatterParseResult frontMatter)
+    {
+        if (string.Equals(cliValue, "arabic", StringComparison.OrdinalIgnoreCase)) return "arabic";
+        if (string.Equals(cliValue, "kanji", StringComparison.OrdinalIgnoreCase)) return "kanji";
+        if (frontMatter.HasFrontMatter && string.Equals(frontMatter.Metadata.NumberStyle, "arabic", StringComparison.OrdinalIgnoreCase)) return "arabic";
+        return "kanji";
     }
 
     private static string InferLawTitle(Zuke.Core.Model.LawDocumentModel model, string inputPath)

--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -50,6 +50,10 @@ public sealed class ExtendedMarkdownRenderer
             var articleTitle = article.ArticleNumber is null
                 ? BuildArticleNumber(article)
                 : $"第{article.ArticleNumber.BaseNumber}条{string.Concat(article.ArticleNumber.BranchNumbers.Select(b => $"の{b}"))}";
+            if (article.ArticleTitle == "附則")
+            {
+                articleTitle = "附則";
+            }
             Append($"### {articleTitle}{(string.IsNullOrWhiteSpace(article.Caption) ? "" : $" {article.Caption}")}{label}");
             mapping.Add(CreateMapping("Article", article.Location?.Line, BuildArticleNumber(article), article.ReferenceName, article.Caption));
             Append("");

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -14,6 +14,7 @@ public sealed class LawtextParser
     private static readonly Regex ParagraphRegex = new(@"^(?<n>[0-9０-９]+)\s*[　 ]*(?<s>.*)$", RegexOptions.Compiled);
     private static readonly Regex ItemRegex = new(@"^\s*(?<n>[一二三四五六七八九十]+)\s*[　 ](?<s>.+)$", RegexOptions.Compiled);
     private static readonly Regex Subitem1Regex = new(@"^\s*(?<n>[イロハニホヘトチリヌルヲワカヨタレソツネナラムウヰノオクヤマケフコエテ])\s*[　 ](?<s>.+)$", RegexOptions.Compiled);
+    private static readonly Regex SupplementaryProvisionRegex = new(@"^\s*附則\s*$", RegexOptions.Compiled);
 
     public (LawDocumentModel Model, IReadOnlyList<DiagnosticMessage> Diagnostics) Parse(string lawtext, string? filePath)
     {
@@ -132,9 +133,24 @@ public sealed class LawtextParser
                 continue;
             }
 
+            if (SupplementaryProvisionRegex.IsMatch(raw))
+            {
+                FlushArticle();
+                currentArticle = new(99999, null, "", "附則", new(filePath, i + 1, 1), []);
+                currentParagraph = new(1, null, null, string.Empty, new(filePath, i + 1, 1), []);
+                items = [];
+                continue;
+            }
+
             if (currentParagraph is not null)
             {
-                currentParagraph = currentParagraph with { SentenceText = string.Concat(currentParagraph.SentenceText, trim) };
+                var lineText = raw.TrimEnd();
+                currentParagraph = currentParagraph with
+                {
+                    SentenceText = string.IsNullOrEmpty(currentParagraph.SentenceText)
+                        ? lineText
+                        : $"{currentParagraph.SentenceText}\n{lineText}"
+                };
                 continue;
             }
 

--- a/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
+++ b/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
@@ -4,10 +4,19 @@ namespace Zuke.Core.Importing;
 
 public sealed class LawtextReferenceDetector
 {
+    private static readonly Regex ProtectedCompositeRegex = new(@"(本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項(?:又は第[0-9０-９一二三四五六七八九十百千]+項|から第[0-9０-９一二三四五六七八九十百千]+項|第[0-9０-９一二三四五六七八九十百千]+号)?", RegexOptions.Compiled);
     private static readonly Regex CandidateRegex = new(@"第?[0-9０-９一二三四五六七八九十百千]+条(?:の[0-9０-９一二三四五六七八九十百千]+)*(?:第?[0-9０-９一二三四五六七八九十百千]+項(?:第?[0-9０-９一二三四五六七八九十百千]+号)?)?|第?[0-9０-９一二三四五六七八九十百千]+項|第?[0-9０-９一二三四五六七八九十百千]+号|前条|前項|前号|次条|次項|次号|同条|同項|同号|及び|又は|から", RegexOptions.Compiled);
 
     public IReadOnlyList<LawtextReferenceToken> Detect(string text)
-        => CandidateRegex.Matches(text).Select(m => new LawtextReferenceToken(m.Value, m.Index, m.Length)).ToList();
+    {
+        var protectedRanges = ProtectedCompositeRegex.Matches(text)
+            .Select(m => (start: m.Index, end: m.Index + m.Length))
+            .ToList();
+        return CandidateRegex.Matches(text)
+            .Where(m => !protectedRanges.Any(r => m.Index >= r.start && (m.Index + m.Length) <= r.end))
+            .Select(m => new LawtextReferenceToken(m.Value, m.Index, m.Length))
+            .ToList();
+    }
 }
 
 public sealed record LawtextReferenceToken(string Text, int Index, int Length);

--- a/src/Zuke.Core/Numbering/NumberingService.cs
+++ b/src/Zuke.Core/Numbering/NumberingService.cs
@@ -24,6 +24,10 @@ public sealed class NumberingService
     private static ArticleNode RenumberArticle(ArticleNode a, int no, bool arabic)
     {
         var ps = a.Paragraphs.Select((p,idx)=> p with { Number = idx+1, ParagraphNumText = JapaneseNumberFormatter.ToParagraphNum(idx+1)}).ToList();
+        if (a.ArticleTitle == "附則")
+        {
+            return a with { Number = no, Paragraphs = ps };
+        }
         var articleNumber = a.ArticleNumber.BaseNumber > 0 ? a.ArticleNumber : ArticleNumber.FromBase(no);
         return a with { Number = no, ArticleNumber = articleNumber, ArticleTitle = ArticleNumberFormatter.ToArticleTitle(articleNumber, arabic), Paragraphs = ps };
     }

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -62,6 +62,7 @@ public sealed class MarkdownLawParser
             if (TryParseArticleHeading(line, currentSection is not null, out var headingText))
             {
                 articleNo++;
+                var headingStartsWithSupplement = headingText.TrimStart().StartsWith("附則", StringComparison.Ordinal);
                 var (caption, articleRefName) = ParseHeading(headingText, "条");
                 var articleStart = i + 1;
                 i++;
@@ -87,7 +88,7 @@ public sealed class MarkdownLawParser
                 {
                     articleNumber = parsedNumber;
                 }
-                var isSupplementaryProvision = string.Equals(caption, "附則", StringComparison.Ordinal);
+                var isSupplementaryProvision = headingStartsWithSupplement || string.Equals(caption, "附則", StringComparison.Ordinal);
                 var articleTitleText = isSupplementaryProvision
                     ? "附則"
                     : ArticleNumberFormatter.ToArticleTitle(articleNumber, false);

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -87,7 +87,11 @@ public sealed class MarkdownLawParser
                 {
                     articleNumber = parsedNumber;
                 }
-                var article = new ArticleNode(articleNo, articleRefName, caption, ArticleNumberFormatter.ToArticleTitle(articleNumber, false), new(filePath, articleStart, 1), paragraphs) { ArticleNumber = articleNumber };
+                var isSupplementaryProvision = string.Equals(caption, "附則", StringComparison.Ordinal);
+                var articleTitleText = isSupplementaryProvision
+                    ? "附則"
+                    : ArticleNumberFormatter.ToArticleTitle(articleNumber, false);
+                var article = new ArticleNode(articleNo, articleRefName, isSupplementaryProvision ? string.Empty : caption, articleTitleText, new(filePath, articleStart, 1), paragraphs) { ArticleNumber = articleNumber };
                 if (currentSection is not null) secArticles.Add(article);
                 else if (currentChapter is not null) chArticles.Add(article);
                 else direct.Add(article);
@@ -215,7 +219,7 @@ public sealed class MarkdownLawParser
                 continue;
             }
 
-            if (TryParseItem(trim, out var itemTitle, out var itemText, out var isSubitem1, out var itemRefName))
+            if (TryParseItem(line, out var itemTitle, out var itemText, out var isSubitem1, out var itemRefName))
             {
                 if (isSubitem1)
                 {
@@ -258,7 +262,7 @@ public sealed class MarkdownLawParser
                 return;
             }
 
-            var sentence = string.Join("", currentSentence);
+            var sentence = string.Join("\n", currentSentence);
             paragraphs.Add(new ParagraphNode(paragraphs.Count + 1, pendingParagraphRef, null, sentence, new(filePath, paraStartLine, 1), [.. currentItems]));
             currentSentence.Clear();
             currentItems.Clear();

--- a/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
@@ -1,0 +1,49 @@
+using Zuke.Core.Compilation;
+using Zuke.Core.Importing;
+using Zuke.Core.Rendering;
+using Xunit;
+
+namespace Zuke.Core.Tests;
+
+public class LawtextImportRegressionTests
+{
+    [Fact]
+    public void RoundTrip_PreservesArabicReferencesBulletsAndSupplementaryProvision()
+    {
+        const string source = """
+就業規則
+
+第1条　この規則は、本条第1項及び本条第6項又は第7項に従う。
+
+第9条　前条第3項及び次条第3項を参照する。
+
+第9条の2　別に定める。
+
+第10条　次のとおりとする。
+  - 通常勤務=...
+  - 時差出勤A=...
+
+附則
+本規則は、◯年◯月◯日から適用する。
+""";
+
+        var imported = new LawtextImportService().Import(source, "regression.law.txt", new());
+        Assert.Contains("numberStyle: arabic", imported.Markdown);
+
+        var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "imported.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+        var rendered = new LawtextRenderer().Render(compiled.Document!, LawtextRenderOptions.Default with { ArabicNumbers = true });
+
+        Assert.Contains("第1条", rendered);
+        Assert.Contains("第9条の2", rendered);
+        Assert.Contains("第10条", rendered);
+        Assert.DoesNotContain("第一条", rendered);
+        Assert.DoesNotContain("第九条の二", rendered);
+        Assert.DoesNotContain("第十条", rendered);
+        Assert.Contains("本条第6項又は第7項", rendered);
+        Assert.DoesNotContain("前条第十七条第三項", rendered);
+        Assert.Contains("- 通常勤務=...", rendered);
+        Assert.Contains("- 時差出勤A=...", rendered);
+        Assert.Contains("附則", rendered);
+    }
+}


### PR DESCRIPTION
### Motivation
- Preserve original article numbering style (e.g. arabic like `第1条`, `第9条の2`) across Lawtext → Markdown → Lawtext round-trip by honoring imported `numberStyle: arabic` when CLI `--number-style` is `auto` or unspecified.
- Avoid expanding relative composite references (e.g. `本条第6項又は第7項`, `同条第4項`, `前条第3項`, `次条第3項`) into absolute references during import/resolve.
- Preserve hyphen bullets and multi-line paragraph content instead of concatenating them into a single sentence. 
- Keep the supplementary provision marker (`附則`) as an independent block rather than absorbing it into the preceding article paragraph.

### Description
- Add `--number-style` default `auto` and implement `ResolveNumberStyle` to prefer an explicit CLI value, then Front Matter `numberStyle` (so `numberStyle: arabic` set by import is applied during `Convert`). (src/Zuke.Cli/Commands/ConvertCommand.cs)
- Protect composite relative-reference patterns in detection by skipping tokenization inside matches like `本条第N項又は第M項` / `前条第N項` / `次条第N項`, preventing inner `第N項` tokens from being resolved separately. (src/Zuke.Core/Importing/LawtextReferenceDetector.cs)
- In Lawtext import, detect a `附則` line and start a supplementary-article node, and stop concatenating lines with `string.Concat` by storing paragraph text with explicit newline joins so hyphen bullets remain separate lines. (src/Zuke.Core/Importing/LawtextParser.cs)
- In Markdown parsing, preserve original paragraph line breaks by joining with `"\n"` and switch item detection to examine the trimmed-but-not-collapsed original `line` to avoid swallowing leading hyphen list lines. (src/Zuke.Core/Parsing/MarkdownLawParser.cs)
- Ensure `附則` is emitted as the article title in the ExtendedMarkdownRenderer path to keep the marker visible in imported Markdown. (src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs)
- Add a regression round-trip test that covers Arabic numbering, composite relative references, hyphen bullets and a supplementary provision (`tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs`).

### Testing
- Ran `dotnet build zuke.sln` and the build succeeded without warnings. (success)
- Ran `dotnet test` and the new regression `LawtextImportRegressionTests.RoundTrip_PreservesArabicReferencesBulletsAndSupplementaryProvision` failed because the final Lawtext render did not contain the standalone `附則` marker; other existing tests passed. (failure — regression test asserts around `附則` preservation)
- `dotnet pack` was not completed as part of the final chained run because the test phase failed first. (not completed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f242e0e2948328b30859a8cc4cf4e1)