### PR TITLE
Preserve supplementary provisions (附則) as dedicated model nodes

### DIFF
--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -42,6 +42,17 @@ public sealed class ExtendedMarkdownRenderer
 
         foreach (var article in model.DirectArticles) RenderArticle(article);
 
+        foreach (var supplementaryProvision in model.SupplementaryProvisions)
+        {
+            Append($"## {supplementaryProvision.Title}");
+            Append("");
+            foreach (var line in supplementaryProvision.Lines)
+            {
+                Append(line);
+            }
+            Append("");
+        }
+
         return (sb.ToString().Replace("\r\n","\n"), mapping);
 
         void RenderArticle(ArticleNode article)
@@ -50,10 +61,6 @@ public sealed class ExtendedMarkdownRenderer
             var articleTitle = article.ArticleNumber is null
                 ? BuildArticleNumber(article)
                 : $"第{article.ArticleNumber.BaseNumber}条{string.Concat(article.ArticleNumber.BranchNumbers.Select(b => $"の{b}"))}";
-            if (article.ArticleTitle == "附則")
-            {
-                articleTitle = "附則";
-            }
             Append($"### {articleTitle}{(string.IsNullOrWhiteSpace(article.Caption) ? "" : $" {article.Caption}")}{label}");
             mapping.Add(CreateMapping("Article", article.Location?.Line, BuildArticleNumber(article), article.ReferenceName, article.Caption));
             Append("");

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -42,6 +42,7 @@ public sealed class LawtextParser
 
         var chapters = new List<ChapterNode>();
         var direct = new List<ArticleNode>();
+        var supplementary = new List<SupplementaryProvisionNode>();
         ChapterNode? currentChapter = null;
         SectionNode? currentSection = null;
         var chArticles = new List<ArticleNode>();
@@ -53,12 +54,27 @@ public sealed class LawtextParser
         var items = new List<ItemNode>();
 
         string? pendingCaption = null;
+        SupplementaryProvisionNode? currentSupplementary = null;
+        var supplementaryLines = new List<string>();
 
         for (var i = Math.Max(index, 0); i < lines.Length; i++)
         {
             var raw = lines[i];
             var trim = raw.Trim();
             if (string.IsNullOrWhiteSpace(trim)) continue;
+
+            if (currentSupplementary is not null)
+            {
+                if (SupplementaryProvisionRegex.IsMatch(raw))
+                {
+                    FlushSupplementary();
+                    currentSupplementary = new SupplementaryProvisionNode("附則", new(filePath, i + 1, 1), []);
+                    continue;
+                }
+
+                supplementaryLines.Add(raw.TrimEnd());
+                continue;
+            }
 
             var cap = CaptionRegex.Match(trim);
             if (cap.Success)
@@ -136,9 +152,10 @@ public sealed class LawtextParser
             if (SupplementaryProvisionRegex.IsMatch(raw))
             {
                 FlushArticle();
-                currentArticle = new(99999, null, "", "附則", new(filePath, i + 1, 1), []);
-                currentParagraph = new(1, null, null, string.Empty, new(filePath, i + 1, 1), []);
-                items = [];
+                FlushSection();
+                FlushChapter();
+                FlushSupplementary();
+                currentSupplementary = new SupplementaryProvisionNode("附則", new(filePath, i + 1, 1), []);
                 continue;
             }
 
@@ -160,8 +177,9 @@ public sealed class LawtextParser
         FlushArticle();
         FlushSection();
         FlushChapter();
+        FlushSupplementary();
 
-        var model = new LawDocumentModel(metadata with { NumberStyle = detectedArticleNumberStyle }, chapters, direct, diags);
+        var model = new LawDocumentModel(metadata with { NumberStyle = detectedArticleNumberStyle }, chapters, direct, supplementary, diags);
         return (model, diags);
 
         void FlushParagraph()
@@ -188,6 +206,15 @@ public sealed class LawtextParser
             else if (currentChapter is not null) chArticles.Add(currentArticle);
             else direct.Add(currentArticle);
             currentArticle = null;
+        }
+
+
+        void FlushSupplementary()
+        {
+            if (currentSupplementary is null) return;
+            supplementary.Add(currentSupplementary with { Lines = [.. supplementaryLines] });
+            supplementaryLines = [];
+            currentSupplementary = null;
         }
 
         void FlushSection()

--- a/src/Zuke.Core/Model/LawDocumentModel.cs
+++ b/src/Zuke.Core/Model/LawDocumentModel.cs
@@ -1,2 +1,18 @@
 namespace Zuke.Core.Model;
-public sealed record LawDocumentModel(LawMetadata Metadata,IReadOnlyList<ChapterNode> Chapters,IReadOnlyList<ArticleNode> DirectArticles,IReadOnlyList<DiagnosticMessage> Diagnostics);
+
+public sealed record LawDocumentModel(
+    LawMetadata Metadata,
+    IReadOnlyList<ChapterNode> Chapters,
+    IReadOnlyList<ArticleNode> DirectArticles,
+    IReadOnlyList<SupplementaryProvisionNode> SupplementaryProvisions,
+    IReadOnlyList<DiagnosticMessage> Diagnostics)
+{
+    public LawDocumentModel(
+        LawMetadata metadata,
+        IReadOnlyList<ChapterNode> chapters,
+        IReadOnlyList<ArticleNode> directArticles,
+        IReadOnlyList<DiagnosticMessage> diagnostics)
+        : this(metadata, chapters, directArticles, [], diagnostics)
+    {
+    }
+}

--- a/src/Zuke.Core/Model/SupplementaryProvisionNode.cs
+++ b/src/Zuke.Core/Model/SupplementaryProvisionNode.cs
@@ -1,0 +1,7 @@
+namespace Zuke.Core.Model;
+
+public sealed record SupplementaryProvisionNode(
+    string Title,
+    SourceLocation? Location,
+    IReadOnlyList<string> Lines
+);

--- a/src/Zuke.Core/Numbering/NumberingService.cs
+++ b/src/Zuke.Core/Numbering/NumberingService.cs
@@ -24,10 +24,6 @@ public sealed class NumberingService
     private static ArticleNode RenumberArticle(ArticleNode a, int no, bool arabic)
     {
         var ps = a.Paragraphs.Select((p,idx)=> p with { Number = idx+1, ParagraphNumText = JapaneseNumberFormatter.ToParagraphNum(idx+1)}).ToList();
-        if (a.ArticleTitle == "附則")
-        {
-            return a with { Number = no, Paragraphs = ps };
-        }
         var articleNumber = a.ArticleNumber.BaseNumber > 0 ? a.ArticleNumber : ArticleNumber.FromBase(no);
         return a with { Number = no, ArticleNumber = articleNumber, ArticleTitle = ArticleNumberFormatter.ToArticleTitle(articleNumber, arabic), Paragraphs = ps };
     }

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -21,6 +21,7 @@ public sealed class MarkdownLawParser
         var chapters = new List<ChapterNode>();
         var direct = new List<ArticleNode>();
         var diagnostics = new List<DiagnosticMessage>();
+        var supplementary = new List<SupplementaryProvisionNode>();
 
         var lines = body.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
 
@@ -59,10 +60,27 @@ public sealed class MarkdownLawParser
                 FlushSection();
             }
 
+            if (TryParseSupplementaryProvisionHeading(line, out var supplementaryTitle))
+            {
+                FlushSection();
+                FlushChapter();
+                var supplementaryStart = i + 1;
+                i++;
+                var supplementaryLines = new List<string>();
+                while (i < lines.Length)
+                {
+                    var t = lines[i].Trim();
+                    if (t.StartsWith("#", StringComparison.Ordinal)) break;
+                    if (!string.IsNullOrWhiteSpace(lines[i])) supplementaryLines.Add(lines[i].TrimEnd());
+                    i++;
+                }
+                supplementary.Add(new SupplementaryProvisionNode(supplementaryTitle, new(filePath, supplementaryStart, 1), supplementaryLines));
+                continue;
+            }
+
             if (TryParseArticleHeading(line, currentSection is not null, out var headingText))
             {
                 articleNo++;
-                var headingStartsWithSupplement = headingText.TrimStart().StartsWith("附則", StringComparison.Ordinal);
                 var (caption, articleRefName) = ParseHeading(headingText, "条");
                 var articleStart = i + 1;
                 i++;
@@ -88,11 +106,8 @@ public sealed class MarkdownLawParser
                 {
                     articleNumber = parsedNumber;
                 }
-                var isSupplementaryProvision = headingStartsWithSupplement || string.Equals(caption, "附則", StringComparison.Ordinal);
-                var articleTitleText = isSupplementaryProvision
-                    ? "附則"
-                    : ArticleNumberFormatter.ToArticleTitle(articleNumber, false);
-                var article = new ArticleNode(articleNo, articleRefName, isSupplementaryProvision ? string.Empty : caption, articleTitleText, new(filePath, articleStart, 1), paragraphs) { ArticleNumber = articleNumber };
+                var articleTitleText = ArticleNumberFormatter.ToArticleTitle(articleNumber, false);
+                var article = new ArticleNode(articleNo, articleRefName, caption, articleTitleText, new(filePath, articleStart, 1), paragraphs) { ArticleNumber = articleNumber };
                 if (currentSection is not null) secArticles.Add(article);
                 else if (currentChapter is not null) chArticles.Add(article);
                 else direct.Add(article);
@@ -110,7 +125,7 @@ public sealed class MarkdownLawParser
 
         FlushSection();
         FlushChapter();
-        return new LawDocumentModel(meta, chapters, direct, diagnostics);
+        return new LawDocumentModel(meta, chapters, direct, supplementary, diagnostics);
 
         void FlushSection()
         {
@@ -151,6 +166,16 @@ public sealed class MarkdownLawParser
         var m = NumberedSectionRegex.Match(text);
         if (m.Success) { title = m.Groups["title"].Value.Trim(); return true; }
         return false;
+    }
+
+    private static bool TryParseSupplementaryProvisionHeading(string line, out string title)
+    {
+        title = string.Empty;
+        if (!line.StartsWith("## ", StringComparison.Ordinal)) return false;
+        var text = line[3..].Trim();
+        if (!text.StartsWith("附則", StringComparison.Ordinal)) return false;
+        title = "附則";
+        return true;
     }
 
     private static bool TryParseArticleHeading(string line, bool insideSection, out string headingText)

--- a/src/Zuke.Core/Rendering/LawtextRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderer.cs
@@ -84,6 +84,26 @@ public sealed class LawtextRenderer
             hasAnyTopLevelBlock = true;
         }
 
+        foreach (var supplementaryProvision in model.SupplementaryProvisions)
+        {
+            if (options.IncludeBlankLineBetweenBlocks && hasAnyTopLevelBlock)
+            {
+                writer.WriteBlankLine();
+            }
+
+            writer.WriteLine(LawtextLineKind.ArticleParagraph, supplementaryProvision.Title);
+            if (options.IncludeBlankLineBetweenBlocks)
+            {
+                writer.WriteBlankLine();
+            }
+
+            foreach (var line in supplementaryProvision.Lines)
+            {
+                writer.WriteLine(LawtextLineKind.Paragraph, line);
+            }
+            hasAnyTopLevelBlock = true;
+        }
+
         var text = writer.ToString(options);
         text = new LawtextNormalizer().Normalize(text, new LawtextNormalizeOptions
         {


### PR DESCRIPTION
### Motivation
- The Lawtext round-trip lost the “附則” block because it was previously represented as a fake `ArticleNode(99999, ...)`, causing it to be treated as a normal article and lost during rendering/numbering.
- Introduce a dedicated model representation for supplementary provisions so they are preserved and not subject to article numbering or article-specific rendering rules.

### Description
- Added `SupplementaryProvisionNode` with `Title`, `Location`, and `Lines`, and extended `LawDocumentModel` with `SupplementaryProvisions` while keeping a 4-argument compatibility constructor to minimize breakage.
- Updated `LawtextParser` to detect `附則`, flush current chapter/section/article state, collect subsequent lines into a `SupplementaryProvisionNode`, and removed the pseudo-article creation (the previous `ArticleNode(99999, ...)` approach).
- Updated `ExtendedMarkdownRenderer` to emit supplementary provisions as dedicated markdown blocks (`## 附則` followed by lines) after direct articles.
- Updated `MarkdownLawParser` to detect `## 附則` before article parsing and create `SupplementaryProvisionNode` entries instead of treating them as articles.
- Updated `LawtextRenderer` to render supplementary provisions as independent trailing blocks after the main provisions, and simplified `NumberingService` by removing the special-case branch for article title == "附則" so supplementary provisions are no longer numbered.

### Testing
- Ran `dotnet build -c Release` and the solution built successfully.
- Ran `dotnet test -c Release` and all tests passed (167 passed, 0 failed), including `LawtextImportRegressionTests.RoundTrip_PreservesArabicReferencesBulletsAndSupplementaryProvision`.
- Ran `dotnet pack -c Release` and packaging completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2468faf088328a5f7217635812059)