### PR TITLE
Preserve Japanese item titles and subitems; avoid converting composite references

### DIFF
--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Zuke.Core.Model;
+using Zuke.Core.Numbering;
 
 namespace Zuke.Core.Importing;
 
@@ -80,11 +81,12 @@ public sealed class ExtendedMarkdownRenderer
         void RenderItem(ArticleNode article, ParagraphNode paragraph, ItemNode item)
         {
             var label = ShouldEmitLabel(item.ReferenceName, "Item") ? $"[号:{item.ReferenceName}] " : string.Empty;
-            Append($"- {label}{item.SentenceText}");
+            var itemTitle = string.IsNullOrWhiteSpace(item.ItemTitle) ? JapaneseNumberFormatter.ToItemTitle(item.Number, false) : item.ItemTitle;
+            Append($"- {label}{itemTitle}　{item.SentenceText}");
             mapping.Add(CreateMapping("Item", item.Location?.Line, $"{BuildParagraphNumber(article, paragraph)}第{item.Number}号", item.ReferenceName, null));
             foreach (var subitem in item.Children)
             {
-                Append($"  - {subitem.ItemTitle} {subitem.SentenceText}");
+                Append($"  {subitem.ItemTitle}　{subitem.SentenceText}");
                 mapping.Add(CreateMapping("Subitem1", subitem.Location?.Line, $"{BuildParagraphNumber(article, paragraph)}第{item.Number}号{subitem.ItemTitle}", subitem.ReferenceName, null));
             }
         }

--- a/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
+++ b/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
@@ -4,13 +4,22 @@ namespace Zuke.Core.Importing;
 
 public sealed class LawtextReferenceDetector
 {
-    private static readonly Regex ProtectedCompositeRegex = new(@"(本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項(?:又は第[0-9０-９一二三四五六七八九十百千]+項|から第[0-9０-９一二三四五六七八九十百千]+項|第[0-9０-９一二三四五六七八九十百千]+号)?", RegexOptions.Compiled);
+    private static readonly Regex[] ProtectedCompositeRegexes =
+    [
+        new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項、第[0-9０-９一二三四五六七八九十百千]+項から第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項、第[0-9０-９一二三四五六七八九十百千]+項又は第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"第[0-9０-９一二三四五六七八九十百千]+項から第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"第[0-9０-９一二三四五六七八九十百千]+項又は第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"第[0-9０-９一二三四五六七八九十百千]+項、第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"第[0-9０-９一二三四五六七八九十百千]+条第[0-9０-９一二三四五六七八九十百千]+項から第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
+        new Regex(@"第[0-9０-９一二三四五六七八九十百千]+条第[0-9０-９一二三四五六七八九十百千]+項又は第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled)
+    ];
     private static readonly Regex CandidateRegex = new(@"第?[0-9０-９一二三四五六七八九十百千]+条(?:の[0-9０-９一二三四五六七八九十百千]+)*(?:第?[0-9０-９一二三四五六七八九十百千]+項(?:第?[0-9０-９一二三四五六七八九十百千]+号)?)?|第?[0-9０-９一二三四五六七八九十百千]+項|第?[0-9０-９一二三四五六七八九十百千]+号|前条|前項|前号|次条|次項|次号|同条|同項|同号|及び|又は|から", RegexOptions.Compiled);
 
     public IReadOnlyList<LawtextReferenceToken> Detect(string text)
     {
-        var protectedRanges = ProtectedCompositeRegex.Matches(text)
-            .Select(m => (start: m.Index, end: m.Index + m.Length))
+        var protectedRanges = ProtectedCompositeRegexes
+            .SelectMany(regex => regex.Matches(text).Select(m => (start: m.Index, end: m.Index + m.Length)))
             .ToList();
         return CandidateRegex.Matches(text)
             .Where(m => !protectedRanges.Any(r => m.Index >= r.start && (m.Index + m.Length) <= r.end))

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -322,6 +322,14 @@ public sealed class MarkdownLawParser
             return true;
         }
 
+        var bulletItem = Regex.Match(text, @"^(?:[-*]|・)\s*(?<title>[一二三四五六七八九十]+)\s*[　 ](?<text>.+)$");
+        if (bulletItem.Success)
+        {
+            title = bulletItem.Groups["title"].Value;
+            sentence = bulletItem.Groups["text"].Value.Trim();
+            return true;
+        }
+
         var bullet = Regex.Match(text, @"^(?:[-*]|・)\s*(?<text>.+)$");
         if (bullet.Success)
         {
@@ -353,9 +361,19 @@ public sealed class MarkdownLawParser
             return true;
         }
 
+        var indentedSubitem = Regex.Match(text, @"^\s{2,}(?<title>[イロハニホヘトチリヌルヲワカヨタレソツネナラムウヰノオクヤマケフコエテアサキユメミシヱヒモセス])\s*[　 ](?<text>.+)$");
+        if (indentedSubitem.Success)
+        {
+            title = indentedSubitem.Groups["title"].Value;
+            sentence = indentedSubitem.Groups["text"].Value.Trim();
+            isSubitem1 = true;
+            return true;
+        }
+
         var item = Regex.Match(text, @"^(?<title>[一二三四五六七八九十]+)\s*[　 ](?<text>.+)$");
         if (item.Success)
         {
+            title = item.Groups["title"].Value;
             sentence = item.Groups["text"].Value.Trim();
             return true;
         }

--- a/src/Zuke.Core/Rendering/LawtextRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderer.cs
@@ -169,8 +169,11 @@ public sealed class LawtextRenderer
     {
         foreach (var item in items)
         {
+            var itemTitle = string.IsNullOrWhiteSpace(item.ItemTitle)
+                ? JapaneseNumberFormatter.ToItemTitle(item.Number, options.ArabicNumbers)
+                : item.ItemTitle;
             writer.WriteLine(LawtextLineKind.Item,
-                $"{options.Layout.ItemIndent}{JapaneseNumberFormatter.ToItemTitle(item.Number, options.ArabicNumbers)}{options.Layout.Separator}{item.SentenceText}");
+                $"{options.Layout.ItemIndent}{itemTitle}{options.Layout.Separator}{item.SentenceText}");
 
             foreach (var subitem in item.Children)
             {

--- a/tests/Zuke.Core.Tests/LawtextImportMarkdownRendererTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportMarkdownRendererTests.cs
@@ -16,4 +16,44 @@ public class LawtextImportMarkdownRendererTests
         Assert.Contains("{{参照:article-2-p1|相対}}", result.Markdown);
         Assert.Contains("{{参照:article-2-p1|完全}}", result.Markdown);
     }
+
+    [Fact]
+    public void RoundTrip_KeepsItemNumbersAndSubitems()
+    {
+        var lawtext = """
+題名
+第1条　本文。
+  一　甲
+  二　次のいずれかの事情があること
+    イ　保育所等
+    ロ　配偶者事情
+  三　第三号
+""";
+        var imported = new LawtextImportService().Import(lawtext, "sample", new());
+        var roundtrip = TestHelpers.RenderLawtext(imported.Markdown);
+        Assert.Contains("一　甲", roundtrip);
+        Assert.Contains("二　次のいずれかの事情があること", roundtrip);
+        Assert.Contains("  イ　保育所等", roundtrip);
+        Assert.Contains("  ロ　配偶者事情", roundtrip);
+        Assert.Contains("\n三　", roundtrip);
+        Assert.DoesNotContain("\n1　", roundtrip);
+        Assert.DoesNotContain("- イ", roundtrip);
+    }
+
+    [Fact]
+    public void RoundTrip_KeepsMultiAndRangeReferences()
+    {
+        var lawtext = """
+題名
+第1条　本文。
+第2条　本条第1項、第3項から第7項にかかわらず
+  一　本条第4項又は第5項に基づく
+""";
+        var imported = new LawtextImportService().Import(lawtext, "sample", new());
+        var roundtrip = TestHelpers.RenderLawtext(imported.Markdown);
+        Assert.Contains("本条第1項、第3項から第7項にかかわらず", roundtrip);
+        Assert.Contains("本条第4項又は第5項に基づく", roundtrip);
+        Assert.DoesNotContain("第2条第3項から第2条第7項", roundtrip);
+        Assert.DoesNotContain("第2条第4項又は第3条第5項", roundtrip);
+    }
 }


### PR DESCRIPTION
### Motivation
- Keep original Lawtext item titles (号) such as `一/二/三` unchanged through Lawtext→Markdown→Lawtext round-trip instead of converting them to Arabic digits.
- Preserve subitem (イ/ロ/ハ) structure and ordering as indented subitems under their parent item rather than converting them to hyphen bullets or moving them before the parent.
- Prevent partial absolute-resolution of multi-item or range references (e.g. `本条第1項、第3項から第7項`) by protecting those composite reference spans from tokenization.

### Description
- Render item titles using `ItemNode.ItemTitle` so original `一/二/...` labels are preserved in the intermediate Markdown and final Lawtext by updating `src/Zuke.Core/Rendering/LawtextRenderer.cs` and `src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs` to prefer stored `ItemTitle` over regenerating numbers.
- Emit subitems as indented `イ　...` lines in `ExtendedMarkdownRenderer` (not as `- イ ...`) and change the Markdown item rendering to include the item title (see `RenderItem`).
- Enhance the Markdown parser (`src/Zuke.Core/Parsing/MarkdownLawParser.cs`) to parse `- 一 ...` as an item with an explicit Japanese title and to treat indented `イ/ロ/...` lines as `Subitem1` children of the preceding item, keeping order and parent-child relation.
- Replace the single complex protected-regex with a set of explicit protected patterns in `src/Zuke.Core/Importing/LawtextReferenceDetector.cs` so multi/ range paragraph references are discovered as protected spans and their internal `第N項` tokens are not individually converted.
- Add regression tests in `tests/Zuke.Core.Tests/LawtextImportMarkdownRendererTests.cs` covering (1) item-number/title preservation, (2) subitem (イ/ロ) preservation and ordering, and (3) multi/range reference preservation.

### Testing
- Ran `dotnet build` and the build succeeded without warnings.
- Ran `dotnet test` and all tests passed (`Passed: 169, Failed: 0`).
- Ran `dotnet pack` and packages were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2493d7ae48328ba84a7daed3ab5b9)