### PR TITLE
Fix remaining Lawtext round-trip issues for item duplication, references, numbering, and supplementary indent

### DIFF
--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -24,6 +24,7 @@ public sealed class ExtendedMarkdownRenderer
             Append($"lawType: {model.Metadata.LawType}");
             Append($"lang: {model.Metadata.Lang}");
             Append($"numberStyle: {model.Metadata.NumberStyle}");
+            Append($"paragraphNumberStyle: {model.Metadata.ParagraphNumberStyle}");
             Append("---");
             Append("");
         }

--- a/src/Zuke.Core/Importing/LawtextParser.cs
+++ b/src/Zuke.Core/Importing/LawtextParser.cs
@@ -39,6 +39,7 @@ public sealed class LawtextParser
 
         var metadata = InferMetadata(title, lawNum, filePath, diags);
         var detectedArticleNumberStyle = "kanji";
+        var detectedParagraphNumberStyle = "fullwidth";
 
         var chapters = new List<ChapterNode>();
         var direct = new List<ArticleNode>();
@@ -128,7 +129,12 @@ public sealed class LawtextParser
             if (para.Success && currentArticle is not null)
             {
                 FlushParagraph();
-                currentParagraph = new(ParseNumber(para.Groups["n"].Value), null, para.Groups["n"].Value, para.Groups["s"].Value.Trim(), new(filePath, i + 1, 1), []);
+                var paraNumText = para.Groups["n"].Value;
+                if (detectedParagraphNumberStyle == "fullwidth" && Regex.IsMatch(paraNumText, "[0-9]"))
+                {
+                    detectedParagraphNumberStyle = "ascii";
+                }
+                currentParagraph = new(ParseNumber(paraNumText), null, paraNumText, para.Groups["s"].Value.Trim(), new(filePath, i + 1, 1), []);
                 continue;
             }
 
@@ -179,7 +185,7 @@ public sealed class LawtextParser
         FlushChapter();
         FlushSupplementary();
 
-        var model = new LawDocumentModel(metadata with { NumberStyle = detectedArticleNumberStyle }, chapters, direct, supplementary, diags);
+        var model = new LawDocumentModel(metadata with { NumberStyle = detectedArticleNumberStyle, ParagraphNumberStyle = detectedParagraphNumberStyle }, chapters, direct, supplementary, diags);
         return (model, diags);
 
         void FlushParagraph()

--- a/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
+++ b/src/Zuke.Core/Importing/LawtextReferenceDetector.cs
@@ -6,6 +6,7 @@ public sealed class LawtextReferenceDetector
 {
     private static readonly Regex[] ProtectedCompositeRegexes =
     [
+        new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項(?:第[0-9０-９一二三四五六七八九十百千]+号)?(?:及び第[0-9０-９一二三四五六七八九十百千]+号)?(?:又は第[0-9０-９一二三四五六七八九十百千]+項)?(?:から第[0-9０-９一二三四五六七八九十百千]+項)?", RegexOptions.Compiled),
         new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項、第[0-9０-９一二三四五六七八九十百千]+項から第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
         new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項、第[0-9０-９一二三四五六七八九十百千]+項又は第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),
         new Regex(@"第[0-9０-９一二三四五六七八九十百千]+項から第[0-9０-９一二三四五六七八九十百千]+項", RegexOptions.Compiled),

--- a/src/Zuke.Core/Importing/LawtextReferenceResolver.cs
+++ b/src/Zuke.Core/Importing/LawtextReferenceResolver.cs
@@ -16,6 +16,7 @@ public sealed class LawtextReferenceResolver
         var detector = new LawtextReferenceDetector();
         foreach (var token in detector.Detect(sentence).OrderByDescending(x => x.Index))
         {
+            if (IsProtectedReferenceToken(sentence, token)) continue;
             if (token.Text is "及び" or "又は") { AddDiag("LMD094", "複数条項参照はMVP未対応です。"); continue; }
             if (token.Text == "から") { AddDiag("LMD095", "範囲参照はMVP未対応です。"); continue; }
             if (token.Text is "次条" or "次項" or "次号" or "同条" or "同項" or "同号") { AddDiag("LMD092", "Lawtextの条項参照を解決できません。"); continue; }
@@ -41,6 +42,13 @@ public sealed class LawtextReferenceResolver
 
         void AddDiag(string code, string message)
             => diags.Add(new(options.Strict ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning, code, message, loc, []));
+    }
+
+    private static bool IsProtectedReferenceToken(string sentence, LawtextReferenceToken token)
+    {
+        var protectedRegex = new Regex(@"(?:本条|同条|前条|次条)第[0-9０-９一二三四五六七八九十百千]+項(?:第[0-9０-９一二三四五六七八九十百千]+号)?(?:及び第[0-9０-９一二三四五六七八九十百千]+号)?(?:又は第[0-9０-９一二三四五六七八九十百千]+項)?(?:から第[0-9０-９一二三四五六七八九十百千]+項)?");
+        return protectedRegex.Matches(sentence)
+            .Any(m => token.Index >= m.Index && (token.Index + token.Length) <= (m.Index + m.Length));
     }
 
     private static bool TryResolveAbsolute(string text, ArticleNode article, ParagraphNode paragraph, out string? replacement)

--- a/src/Zuke.Core/Markdown/FrontMatterParser.cs
+++ b/src/Zuke.Core/Markdown/FrontMatterParser.cs
@@ -45,6 +45,7 @@ public static class FrontMatterParser
                 map.TryGetValue("lang", out var g) ? g.ToString() ?? "" : "")
             {
                 NumberStyle = map.TryGetValue("numberStyle", out var h) ? h?.ToString() ?? "kanji" : "kanji"
+                ,ParagraphNumberStyle = map.TryGetValue("paragraphNumberStyle", out var pns) ? pns?.ToString() ?? "fullwidth" : "fullwidth"
             };
 
             return new FrontMatterParseResult(metadata, bodyNormalized, true, missing);
@@ -71,7 +72,8 @@ public static class FrontMatterParser
 
         return new LawMetadata(title, lawNum, era, year, num, lawType, lang)
         {
-            NumberStyle = TryExtractScalar(yaml, "numberStyle") ?? fallback.NumberStyle
+            NumberStyle = TryExtractScalar(yaml, "numberStyle") ?? fallback.NumberStyle,
+            ParagraphNumberStyle = TryExtractScalar(yaml, "paragraphNumberStyle") ?? fallback.ParagraphNumberStyle
         };
     }
 

--- a/src/Zuke.Core/Model/LawMetadata.cs
+++ b/src/Zuke.Core/Model/LawMetadata.cs
@@ -2,4 +2,5 @@ namespace Zuke.Core.Model;
 public sealed record LawMetadata(string LawTitle,string LawNum,string Era,int Year,int Num,string LawType,string Lang)
 {
     public string NumberStyle { get; init; } = "kanji";
+    public string ParagraphNumberStyle { get; init; } = "fullwidth";
 }

--- a/src/Zuke.Core/Numbering/NumberingService.cs
+++ b/src/Zuke.Core/Numbering/NumberingService.cs
@@ -23,7 +23,7 @@ public sealed class NumberingService
 
     private static ArticleNode RenumberArticle(ArticleNode a, int no, bool arabic)
     {
-        var ps = a.Paragraphs.Select((p,idx)=> p with { Number = idx+1, ParagraphNumText = JapaneseNumberFormatter.ToParagraphNum(idx+1)}).ToList();
+        var ps = a.Paragraphs.Select((p,idx)=> p with { Number = idx+1, ParagraphNumText = p.ParagraphNumText }).ToList();
         var articleNumber = a.ArticleNumber.BaseNumber > 0 ? a.ArticleNumber : ArticleNumber.FromBase(no);
         return a with { Number = no, ArticleNumber = articleNumber, ArticleTitle = ArticleNumberFormatter.ToArticleTitle(articleNumber, arabic), Paragraphs = ps };
     }

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -94,7 +94,7 @@ public sealed class MarkdownLawParser
                     i++;
                 }
 
-                var paragraphs = ParseParagraphs(blockLines, filePath, diagnostics);
+                var paragraphs = ParseParagraphs(blockLines, filePath, diagnostics, meta.ParagraphNumberStyle);
                 if (paragraphs.Count == 0)
                 {
                     paragraphs.Add(new ParagraphNode(1, null, null, string.Empty, new(filePath, articleStart, 1), []));
@@ -217,7 +217,7 @@ public sealed class MarkdownLawParser
         return (caption, name);
     }
 
-    private static List<ParagraphNode> ParseParagraphs(List<(string line, int sourceLine)> blockLines, string? filePath, List<DiagnosticMessage> diagnostics)
+    private static List<ParagraphNode> ParseParagraphs(List<(string line, int sourceLine)> blockLines, string? filePath, List<DiagnosticMessage> diagnostics, string paragraphNumberStyle)
     {
         var paragraphs = new List<ParagraphNode>();
         string? pendingParagraphRef = null;
@@ -289,7 +289,13 @@ public sealed class MarkdownLawParser
             }
 
             var sentence = string.Join("\n", currentSentence);
-            paragraphs.Add(new ParagraphNode(paragraphs.Count + 1, pendingParagraphRef, null, sentence, new(filePath, paraStartLine, 1), [.. currentItems]));
+            var paraNumber = paragraphs.Count + 1;
+            var paraNumText = paraNumber == 1
+                ? null
+                : paragraphNumberStyle.Equals("ascii", StringComparison.OrdinalIgnoreCase)
+                    ? paraNumber.ToString()
+                    : ToFullWidth(paraNumber);
+            paragraphs.Add(new ParagraphNode(paraNumber, pendingParagraphRef, paraNumText, sentence, new(filePath, paraStartLine, 1), [.. currentItems]));
             currentSentence.Clear();
             currentItems.Clear();
             pendingParagraphRef = null;
@@ -380,4 +386,16 @@ public sealed class MarkdownLawParser
 
         return false;
     }
+
+    private static string ToFullWidth(int n) => n.ToString()
+        .Replace("0", "０", StringComparison.Ordinal)
+        .Replace("1", "１", StringComparison.Ordinal)
+        .Replace("2", "２", StringComparison.Ordinal)
+        .Replace("3", "３", StringComparison.Ordinal)
+        .Replace("4", "４", StringComparison.Ordinal)
+        .Replace("5", "５", StringComparison.Ordinal)
+        .Replace("6", "６", StringComparison.Ordinal)
+        .Replace("7", "７", StringComparison.Ordinal)
+        .Replace("8", "８", StringComparison.Ordinal)
+        .Replace("9", "９", StringComparison.Ordinal);
 }

--- a/src/Zuke.Core/Rendering/LawtextRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderer.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Zuke.Core.Model;
 using Zuke.Core.Numbering;
 
@@ -91,7 +92,7 @@ public sealed class LawtextRenderer
                 writer.WriteBlankLine();
             }
 
-            writer.WriteLine(LawtextLineKind.ArticleParagraph, supplementaryProvision.Title);
+            writer.WriteLine(LawtextLineKind.ArticleParagraph, $"      {supplementaryProvision.Title}");
             if (options.IncludeBlankLineBetweenBlocks)
             {
                 writer.WriteBlankLine();
@@ -154,7 +155,7 @@ public sealed class LawtextRenderer
         foreach (var paragraph in article.Paragraphs.Skip(1))
         {
             var paraNum = string.IsNullOrWhiteSpace(paragraph.ParagraphNumText)
-                ? ToFullWidth(paragraph.Number)
+                ? (options.ArabicNumbers ? paragraph.Number.ToString() : ToFullWidth(paragraph.Number))
                 : paragraph.ParagraphNumText;
             var sentence = paragraph.SentenceText;
             var line = string.IsNullOrWhiteSpace(sentence)
@@ -172,8 +173,13 @@ public sealed class LawtextRenderer
             var itemTitle = string.IsNullOrWhiteSpace(item.ItemTitle)
                 ? JapaneseNumberFormatter.ToItemTitle(item.Number, options.ArabicNumbers)
                 : item.ItemTitle;
+            var sentenceText = item.SentenceText;
+            if (!string.IsNullOrWhiteSpace(sentenceText))
+            {
+                sentenceText = Regex.Replace(sentenceText, $"^{Regex.Escape(itemTitle)}[　 ]+", string.Empty);
+            }
             writer.WriteLine(LawtextLineKind.Item,
-                $"{options.Layout.ItemIndent}{itemTitle}{options.Layout.Separator}{item.SentenceText}");
+                $"{options.Layout.ItemIndent}{itemTitle}{options.Layout.Separator}{sentenceText}");
 
             foreach (var subitem in item.Children)
             {

--- a/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
@@ -8,6 +8,43 @@ namespace Zuke.Core.Tests;
 public class LawtextImportRegressionTests
 {
     [Fact]
+    public void RoundTrip_FixesKnownResidualBugs()
+    {
+        const string source = """
+就業規則
+
+第1条　次の各号のいずれかに該当する者は対象外とする。
+一　入社1年未満の従業員
+二　申出の日から1年以内に雇用関係が終了することが明らかな従業員
+三　1週間の所定労働日数が2日以下の従業員
+
+第2条　本条第1項にかかわらず、本条第1項第1号に定める。
+2　会社は、本条第6項又は第7項を準用する。
+3　従業員は、本条第3項第1号による。
+
+      附則
+本規程は、公布の日から施行する。
+""";
+
+        var imported = new LawtextImportService().Import(source, "residual.law.txt", new());
+        Assert.Contains("paragraphNumberStyle: ascii", imported.Markdown);
+        var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "imported.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+        var rendered = new LawtextRenderer().Render(compiled.Document!);
+
+        Assert.Contains("一　入社1年未満の従業員", rendered);
+        Assert.DoesNotContain("一　一　入社1年未満の従業員", rendered);
+        Assert.Contains("本条第1項", rendered);
+        Assert.Contains("本条第1項第1号", rendered);
+        Assert.Contains("本条第6項又は第7項", rendered);
+        Assert.DoesNotContain("本条第5条第1項", rendered);
+        Assert.Contains("会社は、本条第6項又は第7項を準用する。", rendered);
+        Assert.Contains("従業員は、本条第3項第1号による。", rendered);
+        Assert.DoesNotContain("\n２　会社は", rendered);
+        Assert.Contains("\n      附則\n", rendered);
+    }
+
+    [Fact]
     public void RoundTrip_PreservesArabicReferencesBulletsAndSupplementaryProvision()
     {
         const string source = """


### PR DESCRIPTION
### Motivation
- The Lawtext → Markdown → Lawtext round-trip left residual bugs: duplicated item numbers (`一　一 ...`), improper expansion of honjō-style references (e.g. `本条第1項` becoming absolute), paragraph-number style being lost (halfwidth→fullwidth), and loss of `附則` indentation.
- These issues break fidelity of legal source texts and must be preserved through import/compile/render cycles.

### Description
- Prevent duplicated item number output by defensively stripping an `ItemTitle` prefix from `ItemNode.SentenceText` when rendering in `LawtextRenderer` so `一　一 ...` no longer appears. 
- Preserve 6-space indentation for supplementary provision headings by emitting `      附則` in `LawtextRenderer`. 
- Add `ParagraphNumberStyle` to `LawMetadata`, detect paragraph numbering style during `LawtextParser` import, emit `paragraphNumberStyle` into front matter in `ExtendedMarkdownRenderer`, parse it in `FrontMatterParser`, and restore `ParagraphNumText` in `MarkdownLawParser` so original halfwidth/ascii vs fullwidth style is preserved; adjust `NumberingService` to avoid overwriting existing `ParagraphNumText`. 
- Protect composite relative references containing `本条/同条/前条/次条` from tokenization and resolution by extending protected regexes in `LawtextReferenceDetector` and skipping resolution for tokens inside those protected ranges in `LawtextReferenceResolver` to prevent incorrect absolute expansion. 
- Add regression test `RoundTrip_FixesKnownResidualBugs` that validates: item duplication is fixed, honjō references remain as original, paragraph numeral style is preserved, and supplementary heading indentation remains 6 spaces.

### Testing
- Ran `dotnet build` and the build succeeded. 
- Ran `dotnet test` and all tests passed (`170 passed`). 
- Ran `dotnet pack` and package creation succeeded. 
- The repository tests include the new `RoundTrip_FixesKnownResidualBugs` regression test which passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f282349ab48328b3b28b90ae0154f8)