### PR TITLE
Preserve paragraph-level raw bullet indentation in round-trip

### DIFF
--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -292,7 +292,7 @@ public sealed class MarkdownLawParser
                 continue;
             }
 
-            currentSentence.Add(trim);
+            currentSentence.Add(line);
         }
 
         FlushParagraph(blockLines.Count > 0 ? blockLines[^1].sourceLine : 1);

--- a/tests/Zuke.Core.Tests/LawtextImportRoundTripTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportRoundTripTests.cs
@@ -42,6 +42,16 @@ public class LawtextImportRoundTripTests
     }
 
     [Fact]
+    public void RoundTrip_Preserves_ParagraphLevelRawBulletIndent()
+    {
+        var input = "テスト規程\n\n第1条　本文。\n  - 通常勤務=...\n  - 時差出勤A=...\n";
+        var imported = new Zuke.Core.Importing.LawtextImportService().Import(input, "sample", new());
+        var roundTrip = TestHelpers.RenderLawtext(imported.Markdown);
+        Assert.Contains("\n  - 通常勤務=...\n", roundTrip);
+        Assert.Contains("\n  - 時差出勤A=...\n", roundTrip);
+    }
+
+    [Fact]
     public void RoundTrip_DoesNotExpandShortReferences()
     {
         var input = "テスト規程\n\n第1条　第1号及び第2号の措置を実施する。\n  一　第一号\n  二　第二号\n";


### PR DESCRIPTION
### Motivation
- Paragraph-level raw hyphen bullets lost their leading whitespace during Markdown -> model -> Lawtext round-trip, causing indent differences for bullets directly under a paragraph.

### Description
- Changed `MarkdownLawParser` to store paragraph sentence lines using the original `line` (preserving leading whitespace) instead of the trimmed `trim` in `ParseParagraphs`.
- Added a round-trip regression test `RoundTrip_Preserves_ParagraphLevelRawBulletIndent` in `tests/Zuke.Core.Tests/LawtextImportRoundTripTests.cs` to verify that a two-space indent before `- ...` directly under a paragraph is preserved.
- Only the paragraph sentence collection behavior was modified; item/subitem handling was not changed.

### Testing
- Ran `dotnet build` which succeeded.
- Ran `dotnet test` which passed all tests (181 passed).
- Ran `dotnet pack` which produced NuGet packages successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ee1a7fb08328b7933088bfc3dab5)