### PR TITLE
Preserve ascii paragraph numbers through Front Matter normalization and tests

### DIFF
--- a/src/Zuke.Core/Markdown/FrontMatterParser.cs
+++ b/src/Zuke.Core/Markdown/FrontMatterParser.cs
@@ -33,19 +33,19 @@ public static class FrontMatterParser
         {
             var deserializer = new DeserializerBuilder().WithNamingConvention(CamelCaseNamingConvention.Instance).Build();
             var map = deserializer.Deserialize<Dictionary<string, object>>(yaml) ?? new();
-            var missing = RequiredKeys.Where(k => !map.ContainsKey(k) || string.IsNullOrWhiteSpace(map[k]?.ToString())).ToList();
+            var missing = RequiredKeys.Where(k => string.IsNullOrWhiteSpace(GetValue(map, k))).ToList();
 
             var metadata = new LawMetadata(
-                map.TryGetValue("lawTitle", out var a) ? a.ToString() ?? "" : "",
-                map.TryGetValue("lawNum", out var b) ? b.ToString() ?? "" : "",
-                map.TryGetValue("era", out var c) ? c.ToString() ?? "" : "",
-                map.TryGetValue("year", out var d) ? Convert.ToInt32(d) : 1,
-                map.TryGetValue("num", out var e) ? Convert.ToInt32(e) : 1,
-                map.TryGetValue("lawType", out var f) ? f.ToString() ?? "" : "",
-                map.TryGetValue("lang", out var g) ? g.ToString() ?? "" : "")
+                GetValue(map, "lawTitle") ?? string.Empty,
+                GetValue(map, "lawNum") ?? string.Empty,
+                GetValue(map, "era") ?? string.Empty,
+                int.TryParse(GetValue(map, "year"), out var year) ? year : 1,
+                int.TryParse(GetValue(map, "num"), out var num) ? num : 1,
+                GetValue(map, "lawType") ?? string.Empty,
+                GetValue(map, "lang") ?? string.Empty)
             {
-                NumberStyle = map.TryGetValue("numberStyle", out var h) ? h?.ToString() ?? "kanji" : "kanji"
-                ,ParagraphNumberStyle = map.TryGetValue("paragraphNumberStyle", out var pns) ? pns?.ToString() ?? "fullwidth" : "fullwidth"
+                NumberStyle = NormalizeNumberStyle(GetValue(map, "numberStyle")),
+                ParagraphNumberStyle = NormalizeParagraphNumberStyle(GetValue(map, "paragraphNumberStyle"))
             };
 
             return new FrontMatterParseResult(metadata, bodyNormalized, true, missing);
@@ -72,8 +72,8 @@ public static class FrontMatterParser
 
         return new LawMetadata(title, lawNum, era, year, num, lawType, lang)
         {
-            NumberStyle = TryExtractScalar(yaml, "numberStyle") ?? fallback.NumberStyle,
-            ParagraphNumberStyle = TryExtractScalar(yaml, "paragraphNumberStyle") ?? fallback.ParagraphNumberStyle
+            NumberStyle = NormalizeNumberStyle(TryExtractScalar(yaml, "numberStyle") ?? fallback.NumberStyle),
+            ParagraphNumberStyle = NormalizeParagraphNumberStyle(TryExtractScalar(yaml, "paragraphNumberStyle") ?? fallback.ParagraphNumberStyle)
         };
     }
 
@@ -88,7 +88,7 @@ public static class FrontMatterParser
             if (separatorIndex <= 0) continue;
 
             var left = line[..separatorIndex].Trim();
-            if (!left.Equals(key, StringComparison.Ordinal)) continue;
+            if (!left.Equals(key, StringComparison.OrdinalIgnoreCase)) continue;
 
             var right = line[(separatorIndex + 1)..].Trim();
             if (right.Length >= 2)
@@ -105,6 +105,25 @@ public static class FrontMatterParser
         return null;
     }
 
+
+    private static string? GetValue(Dictionary<string, object> map, string key)
+    {
+        foreach (var entry in map)
+        {
+            if (entry.Key.Equals(key, StringComparison.OrdinalIgnoreCase))
+            {
+                return entry.Value?.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeParagraphNumberStyle(string? value)
+        => value != null && value.Equals("ascii", StringComparison.OrdinalIgnoreCase) ? "ascii" : "fullwidth";
+
+    private static string NormalizeNumberStyle(string? value)
+        => value != null && value.Equals("arabic", StringComparison.OrdinalIgnoreCase) ? "arabic" : "kanji";
     public static IReadOnlyList<DiagnosticMessage> ValidateRequired(FrontMatterParseResult result, string? filePath)
     {
         if (!result.HasFrontMatter)

--- a/tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs
+++ b/tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs
@@ -1,0 +1,74 @@
+using Zuke.Core.Compilation;
+using Zuke.Core.Markdown;
+using Zuke.Core.Rendering;
+using Xunit;
+
+namespace Zuke.Core.Tests;
+
+public class ParagraphNumberStyleTests
+{
+    [Fact]
+    public void FrontMatterParser_ParsesParagraphNumberStyleAscii()
+    {
+        const string markdown = """
+---
+lawTitle: 就業規則
+lawNum:
+era: Reiwa
+year: 1
+num: 1
+lawType: Misc
+lang: ja
+numberStyle: arabic
+paragraphNumberStyle: ascii
+---
+
+# 本則
+
+### 第1条 目的
+
+本文。
+2　会社は...
+""";
+
+        var parsed = FrontMatterParser.ParseDetailed(markdown);
+
+        Assert.Equal("ascii", parsed.Metadata.ParagraphNumberStyle);
+    }
+
+    [Fact]
+    public void MarkdownRoundTrip_PreservesAsciiParagraphNumbers()
+    {
+        const string markdown = """
+---
+lawTitle: 就業規則
+lawNum:
+era: Reiwa
+year: 1
+num: 1
+lawType: Misc
+lang: ja
+numberStyle: arabic
+paragraphNumberStyle: ascii
+---
+
+# 本則
+
+### 第2条 目的
+
+本条第1項にかかわらず、本条第1項第1号に定める。
+2　会社は、本条第6項又は第7項を準用する。
+3　従業員は、本条第3項第1号による。
+""";
+
+        var compiled = new LawMarkdownCompiler().Compile(markdown, "sample.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+
+        var rendered = new LawtextRenderer().Render(compiled.Document!);
+
+        Assert.Contains("\n2　会社は", rendered);
+        Assert.Contains("\n3　従業員は", rendered);
+        Assert.DoesNotContain("\n２　会社は", rendered);
+        Assert.DoesNotContain("\n３　従業員は", rendered);
+    }
+}


### PR DESCRIPTION
### Motivation

- A round-trip test showed `paragraphNumberStyle: ascii` was not preserved and paragraph numbers became fullwidth, so Front Matter parsing needs to reliably detect and propagate the setting. 

### Description

- Harden `FrontMatterParser.ParseDetailed` to read YAML keys case-insensitively using a new `GetValue` helper and to canonicalize `numberStyle` and `paragraphNumberStyle` via `NormalizeNumberStyle` and `NormalizeParagraphNumberStyle`.
- Make best-effort scalar extraction in `TryExtractScalar` case-insensitive for key names so plain-text YAML fallback respects keys regardless of case.
- Use normalized values when constructing `LawMetadata` in both normal and best-effort parsing paths so `metadata.ParagraphNumberStyle` is either `ascii` or `fullwidth` consistently.
- Add `tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs` with `FrontMatterParser_ParsesParagraphNumberStyleAscii` and `MarkdownRoundTrip_PreservesAsciiParagraphNumbers` to assert front matter parsing and round-trip rendering preserve ASCII paragraph numbers.

### Testing

- Ran `dotnet test -c Release` and the test suite passed (all tests passed, including the added `ParagraphNumberStyleTests` and the previously failing `RoundTrip_FixesKnownResidualBugs`).
- Ran `dotnet build -c Release` and `dotnet pack -c Release`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34bdf2ae08328939746fe2b8c27f0)