### PR TITLE
Render SupplProvision body as Paragraph for XSD compliance

### DIFF
--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -107,9 +107,12 @@ public sealed class LawXmlRenderer
             if (supplementaryProvision.Lines.Count > 0)
             {
                 supplElements.Add(
-                    new XElement("SupplProvisionSentence",
-                        supplementaryProvision.Lines.Select((line, idx) =>
-                            new XElement("Sentence", new XAttribute("Num", idx + 1), line))));
+                    new XElement("Paragraph",
+                        new XAttribute("Num", 1),
+                        new XElement("ParagraphNum"),
+                        new XElement("ParagraphSentence",
+                            supplementaryProvision.Lines.Select((line, idx) =>
+                                new XElement("Sentence", new XAttribute("Num", idx + 1), line)))));
             }
 
             yield return new XElement("SupplProvision", supplElements.ToArray());

--- a/tests/Zuke.Core.Tests/XmlRenderingTests.cs
+++ b/tests/Zuke.Core.Tests/XmlRenderingTests.cs
@@ -88,7 +88,7 @@ lang: ja
     }
 
     [Fact]
-    public void XmlRendersSupplementaryProvision()
+    public void XmlRendersSupplementaryProvisionAsParagraph()
     {
         const string markdown = """
 # テスト規則
@@ -103,7 +103,10 @@ lang: ja
 
         Assert.Contains("<SupplProvision>", xml);
         Assert.Contains("<SupplProvisionLabel>附則</SupplProvisionLabel>", xml);
-        Assert.Contains("本規則は、◯年◯月◯日から適用する。", xml);
+        Assert.DoesNotContain("<SupplProvisionSentence>", xml);
+        Assert.Contains("<Paragraph Num=\"1\">", xml);
+        Assert.Contains("<ParagraphNum />", xml);
+        Assert.Contains("<ParagraphSentence><Sentence Num=\"1\">本規則は、◯年◯月◯日から適用する。</Sentence></ParagraphSentence>", xml);
     }
 
     private static string RenderXml(string markdown)

--- a/tests/Zuke.Core.Tests/XsdValidationTests.cs
+++ b/tests/Zuke.Core.Tests/XsdValidationTests.cs
@@ -68,4 +68,35 @@ lang: ja
         var diags = new LawXmlValidator().Validate(broken, xsd);
         Assert.Contains(diags, d => d.Code == "LMD044");
     }
+
+    [Fact]
+    public void SupplementaryProvision_GeneratesValidXml()
+    {
+        var md = """
+---
+lawTitle: テスト規則
+lawNum: テスト第1号
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+# テスト規則
+
+## 第一条
+本文。
+
+## 附則
+本規則は、◯年◯月◯日から適用する。
+""";
+        var result = TestHelpers.Compile(md);
+        Assert.False(result.HasErrors);
+
+        var xml = new LawXmlRenderer().Render(result.Document!.Document);
+        Assert.DoesNotContain("<SupplProvisionSentence>", xml.ToString(SaveOptions.DisableFormatting));
+        var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
+        var diags = new LawXmlValidator().Validate(xml, xsd);
+        Assert.DoesNotContain(diags, d => d.Code == "LMD044");
+    }
 }


### PR DESCRIPTION
### Motivation

- `SupplProvisionSentence` was being emitted under `<SupplProvision>`, which is invalid per `XMLSchemaForJapaneseLaw_v3.xsd` because `SupplProvision` must contain `Chapter`/`Article`/`Paragraph`-style children after the label.

### Description

- Changed `LawXmlRenderer` to stop emitting `<SupplProvisionSentence>` and instead render the supplementary provision body as a `<Paragraph Num="1">` with a `<ParagraphNum />` and `<ParagraphSentence><Sentence .../></ParagraphSentence>` child using `SupplementaryProvisionNode.Lines`.
- Updated `tests/Zuke.Core.Tests/XmlRenderingTests.cs` to rename the test to `XmlRendersSupplementaryProvisionAsParagraph` and to assert that `<SupplProvisionSentence>` is absent and the `<Paragraph>` structure is present.
- Added `SupplementaryProvision_GeneratesValidXml` in `tests/Zuke.Core.Tests/XsdValidationTests.cs` to validate that generated XML containing 附則 does not include `<SupplProvisionSentence>` and passes XSD validation.
- Kept existing behavior for raw hyphen bullets (do not reintroduce `<Subitem1Title>-</Subitem1Title>`), preserving the prior handling in `LawXmlRenderer`.

### Testing

- Ran `dotnet build -c Release` and the build succeeded. 
- Ran `dotnet test -c Release` and all tests passed (188 passed). 
- Ran `dotnet pack -c Release` and packages were created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35dc207e88328b77837146eb43d1f)