### PR TITLE
Support raw bullet lists as XML List elements

### DIFF
--- a/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
+++ b/src/Zuke.Core/Importing/ExtendedMarkdownRenderer.cs
@@ -81,6 +81,15 @@ public sealed class ExtendedMarkdownRenderer
 
         void RenderItem(ArticleNode article, ParagraphNode paragraph, ItemNode item)
         {
+            if (item.IsRawBullet)
+            {
+                var marker = string.IsNullOrWhiteSpace(item.ItemTitle) ? "-" : item.ItemTitle;
+                var indent = string.IsNullOrEmpty(item.LeadingWhitespace) ? "  " : item.LeadingWhitespace;
+                Append($"{indent}{marker} {item.SentenceText}");
+                mapping.Add(CreateMapping("List", item.Location?.Line, $"{BuildParagraphNumber(article, paragraph)}List", item.ReferenceName, null));
+                return;
+            }
+
             var label = ShouldEmitLabel(item.ReferenceName, "Item") ? $"[号:{item.ReferenceName}] " : string.Empty;
             var itemTitle = string.IsNullOrWhiteSpace(item.ItemTitle) ? JapaneseNumberFormatter.ToItemTitle(item.Number, false) : item.ItemTitle;
             Append($"- {label}{itemTitle}　{item.SentenceText}");

--- a/src/Zuke.Core/Parsing/MarkdownLawParser.cs
+++ b/src/Zuke.Core/Parsing/MarkdownLawParser.cs
@@ -245,21 +245,29 @@ public sealed class MarkdownLawParser
                 continue;
             }
 
-            var rawBulletChild = Regex.Match(line, @"^(?<indent>\s{2,})-\s*(?<text>.+)$");
-            if (rawBulletChild.Success && currentItems.Count > 0)
+            var rawBulletChild = Regex.Match(line, @"^(?<indent>\s{2,})(?<marker>[-・])\s*(?<text>.+)$");
+            if (rawBulletChild.Success && currentItems.Count > 0 && !currentItems[^1].IsRawBullet)
             {
                 var parent = currentItems[^1];
                 var children = parent.Children.ToList();
                 children.Add(new ItemNode(
                     children.Count + 1,
                     null,
-                    "-",
+                    rawBulletChild.Groups["marker"].Value,
                     rawBulletChild.Groups["text"].Value.Trim(),
                     new(filePath, lineNo, 1),
                     [],
                     rawBulletChild.Groups["indent"].Value,
                     true));
                 currentItems[^1] = parent with { Children = children };
+                continue;
+            }
+
+            var rawBulletParagraph = Regex.Match(line, @"^(?<indent>\s{2,})(?<marker>[-・])\s*(?<text>.+)$");
+            if (rawBulletParagraph.Success)
+            {
+                var nextNo = ++itemNo;
+                currentItems.Add(new ItemNode(nextNo, null, rawBulletParagraph.Groups["marker"].Value, rawBulletParagraph.Groups["text"].Value.Trim(), new(filePath, lineNo, 1), [], rawBulletParagraph.Groups["indent"].Value, true));
                 continue;
             }
 

--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -60,7 +60,20 @@ public sealed class LawXmlRenderer
     private static XElement RenderParagraph(ParagraphNode p, LawXmlRenderOptions options)
     {
         var sentence = string.IsNullOrWhiteSpace(p.SentenceText) ? string.Empty : p.SentenceText;
-        return new("Paragraph", new XAttribute("Num", p.Number), string.IsNullOrEmpty(p.ParagraphNumText) ? new XElement("ParagraphNum") : new XElement("ParagraphNum", p.ParagraphNumText), new XElement("ParagraphSentence", new XElement("Sentence", new XAttribute("Num", 1), sentence)), p.Items.Select(i => RenderItem(i, options)));
+        var paragraph = new XElement("Paragraph", new XAttribute("Num", p.Number), string.IsNullOrEmpty(p.ParagraphNumText) ? new XElement("ParagraphNum") : new XElement("ParagraphNum", p.ParagraphNumText), new XElement("ParagraphSentence", new XElement("Sentence", new XAttribute("Num", 1), sentence)));
+        foreach (var item in p.Items)
+        {
+            if (item.IsRawBullet)
+            {
+                paragraph.Add(RenderList(item));
+            }
+            else
+            {
+                paragraph.Add(RenderItem(item, options));
+            }
+        }
+
+        return paragraph;
     }
 
     private static XElement RenderItem(ItemNode i, LawXmlRenderOptions options)
@@ -72,27 +85,24 @@ public sealed class LawXmlRenderer
         var e = new XElement("Item", new XAttribute("Num", i.Number), new XElement("ItemTitle", itemTitle), new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1), itemSentence)));
         foreach (var child in i.Children)
         {
-            if (string.Equals(child.ItemTitle, "-", StringComparison.Ordinal))
+            if (child.IsRawBullet)
             {
-                var fallback = NormalizeSentence(child.SentenceText, "-");
-                if (!string.IsNullOrWhiteSpace(fallback))
-                {
-                    var sentenceElement = e.Element("ItemSentence")?.Element("Sentence");
-                    if (sentenceElement is not null)
-                    {
-                        var current = sentenceElement.Value;
-                        sentenceElement.Value = string.IsNullOrWhiteSpace(current) ? fallback : $"{current}\n{fallback}";
-                    }
-                }
-
+                e.Add(RenderList(child));
                 continue;
             }
 
-            var subitemSentence = NormalizeSentence(child.SentenceText, child.ItemTitle);
+                        var subitemSentence = NormalizeSentence(child.SentenceText, child.ItemTitle);
             e.Add(new XElement("Subitem1", new XAttribute("Num", child.Number), new XElement("Subitem1Title", child.ItemTitle), new XElement("Subitem1Sentence", new XElement("Sentence", new XAttribute("Num", 1), subitemSentence))));
         }
 
         return e;
+    }
+
+    private static XElement RenderList(ItemNode rawListItem)
+    {
+        return new XElement("List",
+            new XElement("ListSentence",
+                new XElement("Sentence", new XAttribute("Num", 1), rawListItem.SentenceText)));
     }
 
     private static IEnumerable<XElement> RenderSupplementaryProvisions(LawDocumentModel model)

--- a/src/Zuke.Core/Rendering/LawtextRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawtextRenderer.cs
@@ -170,6 +170,13 @@ public sealed class LawtextRenderer
     {
         foreach (var item in items)
         {
+            if (item.IsRawBullet)
+            {
+                var marker = string.IsNullOrWhiteSpace(item.ItemTitle) ? "-" : item.ItemTitle;
+                writer.WriteLine(LawtextLineKind.Item, $"{(item.LeadingWhitespace ?? options.Layout.ItemIndent)}{marker} {item.SentenceText}");
+                continue;
+            }
+
             var itemTitle = string.IsNullOrWhiteSpace(item.ItemTitle)
                 ? JapaneseNumberFormatter.ToItemTitle(item.Number, options.ArabicNumbers)
                 : item.ItemTitle;
@@ -185,7 +192,8 @@ public sealed class LawtextRenderer
             {
                 if (subitem.IsRawBullet)
                 {
-                    writer.WriteLine(LawtextLineKind.Subitem1, $"{(subitem.LeadingWhitespace ?? options.Layout.Subitem1Indent)}- {subitem.SentenceText}");
+                    var marker = string.IsNullOrWhiteSpace(subitem.ItemTitle) ? "-" : subitem.ItemTitle;
+                    writer.WriteLine(LawtextLineKind.Subitem1, $"{(subitem.LeadingWhitespace ?? options.Layout.Subitem1Indent)}{marker} {subitem.SentenceText}");
                     continue;
                 }
                 writer.WriteLine(LawtextLineKind.Subitem1,


### PR DESCRIPTION
### Motivation
- Preserve structural information for indented raw bullets (e.g. `-` / `・`) so round-trip to Lawtext/Markdown/XML/Word can restore original marker and indent instead of flattening them into plain sentence text or forcing them into numbered `Item` forms.
- Emit standard-compliant `<List>` elements in XML for raw bullets to avoid producing `<Subitem1Title>-</Subitem1Title>` and to keep LawXML interoperable while retaining zuke-specific restoration info in other layers.

### Description
- `MarkdownLawParser` now recognizes indented `-` / `・` lines as raw-bullet entries at paragraph level and as raw-bullet children under an `Item`, and marks them with `IsRawBullet = true` while preserving `LeadingWhitespace` and the original `marker` in `ItemTitle` for restoration.;
- `LawXmlRenderer` emits raw bullets as `<List><ListSentence><Sentence>...</Sentence></ListSentence></List>` via a new `RenderList` helper and stops folding raw-bullet children into `ItemSentence` or producing `<Subitem1Title>-</Subitem1Title>`; 
- `LawtextRenderer` outputs raw bullets using the original `marker` and `LeadingWhitespace` so Lawtext preserves the `-`/`・` and indent; 
- `ExtendedMarkdownRenderer` preserves and emits paragraph-level raw bullets as `indent + marker + text` (and records a `List` mapping entry) instead of coercing them into numbered `Item` lines.

### Testing
- Ran `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj --filter "XmlRenderingTests|MarkdownListParsingTests|LawtextImportRoundTripTests"` and the filtered test set passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38be6021483289e14380885bb6d7a)