### PR TITLE
Render raw bullet items as Item containing List and add XSD validation tests

### DIFF
--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -65,7 +65,7 @@ public sealed class LawXmlRenderer
         {
             if (item.IsRawBullet)
             {
-                paragraph.Add(RenderList(item));
+                paragraph.Add(RenderRawBulletItem(item, options));
             }
             else
             {
@@ -103,6 +103,18 @@ public sealed class LawXmlRenderer
         return new XElement("List",
             new XElement("ListSentence",
                 new XElement("Sentence", new XAttribute("Num", 1), rawListItem.SentenceText)));
+    }
+
+    private static XElement RenderRawBulletItem(ItemNode i, LawXmlRenderOptions options)
+    {
+        var itemTitle = string.IsNullOrWhiteSpace(i.ItemTitle)
+            ? JapaneseNumberFormatter.ToItemTitle(i.Number, options.ArabicNumbers)
+            : i.ItemTitle;
+        return new XElement("Item",
+            new XAttribute("Num", i.Number),
+            new XElement("ItemTitle", itemTitle),
+            new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1))),
+            RenderList(i));
     }
 
     private static IEnumerable<XElement> RenderSupplementaryProvisions(LawDocumentModel model)

--- a/tests/Zuke.Core.Tests/XsdValidationTests.cs
+++ b/tests/Zuke.Core.Tests/XsdValidationTests.cs
@@ -1,4 +1,6 @@
 using System.Xml.Linq;
+using Zuke.Core.Compilation;
+using Zuke.Core.Importing;
 using Xunit;
 using Zuke.Core.Rendering;
 using Zuke.Core.Validation;
@@ -7,6 +9,20 @@ namespace Zuke.Core.Tests;
 
 public class XsdValidationTests
 {
+    [Fact]
+    public void CurrentRealXsdIsStrict()
+    {
+        var xsdPath = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
+        var xsdText = File.ReadAllText(xsdPath);
+
+        Assert.DoesNotContain("<xs:element name=\"LawBody\" type=\"xs:anyType\"", xsdText);
+        Assert.Contains("<xs:element name=\"Article\"", xsdText);
+        Assert.Contains("<xs:element name=\"Paragraph\"", xsdText);
+        Assert.Contains("<xs:element name=\"Item\"", xsdText);
+        Assert.Contains("<xs:element name=\"SupplProvision\"", xsdText);
+        Assert.Contains("<xs:element name=\"List\"", xsdText);
+    }
+
     [Fact]
     public void WorkRules_GeneratesValidXml()
     {
@@ -95,6 +111,46 @@ lang: ja
 
         var xml = new LawXmlRenderer().Render(result.Document!.Document);
         Assert.DoesNotContain("<SupplProvisionSentence>", xml.ToString(SaveOptions.DisableFormatting));
+        var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
+        var diags = new LawXmlValidator().Validate(xml, xsd);
+        Assert.DoesNotContain(diags, d => d.Code == "LMD044");
+    }
+
+    [Fact]
+    public void IkujiKaigoLawtext_GeneratesValidXml_WithOfficialXsd()
+    {
+        var source = File.ReadAllText(Path.Combine(TestHelpers.RepoRoot, "samples", "ikuji_kaigo_kyugyo_kitei_lawtext.txt"));
+        var imported = new LawtextImportService().Import(source, "samples/ikuji_kaigo_kyugyo_kitei_lawtext.txt", new());
+
+        var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "samples/ikuji_kaigo_kyugyo_kitei_lawtext.imported.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+
+        var xml = new LawXmlRenderer().Render(compiled.Document!.Document);
+        var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
+        var diags = new LawXmlValidator().Validate(xml, xsd);
+
+        Assert.DoesNotContain(diags, d => d.Code == "LMD044");
+    }
+
+    [Fact]
+    public void RawBulletList_GeneratesValidXml_WithOfficialXsd()
+    {
+        const string lawtext = """
+箇条書きテスト規程
+
+第1条　次の事項を定める。
+  - 勤務区分A
+  - 勤務区分B
+""";
+        var imported = new LawtextImportService().Import(lawtext, "raw-bullet.law.txt", new());
+        var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "raw-bullet.imported.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+
+        var xml = new LawXmlRenderer().Render(compiled.Document!.Document);
+        var xmlText = xml.ToString(SaveOptions.DisableFormatting);
+        Assert.Contains("<List>", xmlText);
+        Assert.DoesNotContain("<Subitem1Title>-</Subitem1Title>", xmlText);
+
         var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
         var diags = new LawXmlValidator().Validate(xml, xsd);
         Assert.DoesNotContain(diags, d => d.Code == "LMD044");


### PR DESCRIPTION
### Motivation

- Ensure raw bullet lists are emitted as valid `Item` elements containing a `List` so generated XML conforms to the official schema instead of inserting a bare `List` directly in a `Paragraph`.
- Add tests that validate renderer output against the official XSD and guard against schema regressions.

### Description

- Updated `LawXmlRenderer.RenderParagraph` to call a new `RenderRawBulletItem` helper when `ItemNode.IsRawBullet` is true instead of directly adding a bare `List` element.  
- Added `RenderRawBulletItem` which emits an `Item` with `ItemTitle`, an empty `ItemSentence` `Sentence`, and the `List` returned from `RenderList`.  
- Left existing behavior for raw bullet children inside regular `Item` nodes unchanged by keeping `RenderList(child)` inside `RenderItem`.  
- Expanded `XsdValidationTests` with new tests: `CurrentRealXsdIsStrict`, `IkujiKaigoLawtext_GeneratesValidXml_WithOfficialXsd`, and `RawBulletList_GeneratesValidXml_WithOfficialXsd`, and added necessary imports for `LawtextImportService` and `LawMarkdownCompiler` usage in tests.

### Testing

- Ran the `XsdValidationTests` suite which includes the new `CurrentRealXsdIsStrict`, `IkujiKaigoLawtext_GeneratesValidXml_WithOfficialXsd`, and `RawBulletList_GeneratesValidXml_WithOfficialXsd` tests.  
- The `RawBulletList` test asserts the presence of `<List>` and absence of `'<Subitem1Title>-</Subitem1Title>'` in output and that no `LMD044` diagnostics are returned by the `LawXmlValidator`.  
- Executed `dotnet test` for the test project and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cc24a11c83289bf29c881414f6eb)