### PR TITLE
Render raw bullets as untitled <Item> elements with paragraph-scoped renumbering and update XSD tests

### DIFF
--- a/src/Zuke.Core/Rendering/LawXmlRenderer.cs
+++ b/src/Zuke.Core/Rendering/LawXmlRenderer.cs
@@ -61,28 +61,31 @@ public sealed class LawXmlRenderer
     {
         var sentence = string.IsNullOrWhiteSpace(p.SentenceText) ? string.Empty : p.SentenceText;
         var paragraph = new XElement("Paragraph", new XAttribute("Num", p.Number), string.IsNullOrEmpty(p.ParagraphNumText) ? new XElement("ParagraphNum") : new XElement("ParagraphNum", p.ParagraphNumText), new XElement("ParagraphSentence", new XElement("Sentence", new XAttribute("Num", 1), sentence)));
+        var needsParagraphScopedRenumbering = p.Items.Any(i => i.IsRawBullet);
+        var itemNum = 1;
         foreach (var item in p.Items)
         {
+            var outputNum = needsParagraphScopedRenumbering ? itemNum++ : item.Number;
             if (item.IsRawBullet)
             {
-                paragraph.Add(RenderRawBulletItem(item, options));
+                paragraph.Add(RenderRawBulletAsUntitledItem(item, outputNum));
             }
             else
             {
-                paragraph.Add(RenderItem(item, options));
+                paragraph.Add(RenderItem(item, options, outputNum));
             }
         }
 
         return paragraph;
     }
 
-    private static XElement RenderItem(ItemNode i, LawXmlRenderOptions options)
+    private static XElement RenderItem(ItemNode i, LawXmlRenderOptions options, int? numOverride = null)
     {
         var itemTitle = string.IsNullOrWhiteSpace(i.ItemTitle)
             ? JapaneseNumberFormatter.ToItemTitle(i.Number, options.ArabicNumbers)
             : i.ItemTitle;
         var itemSentence = NormalizeSentence(i.SentenceText, itemTitle);
-        var e = new XElement("Item", new XAttribute("Num", i.Number), new XElement("ItemTitle", itemTitle), new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1), itemSentence)));
+        var e = new XElement("Item", new XAttribute("Num", numOverride ?? i.Number), new XElement("ItemTitle", itemTitle), new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1), itemSentence)));
         foreach (var child in i.Children)
         {
             if (child.IsRawBullet)
@@ -91,7 +94,7 @@ public sealed class LawXmlRenderer
                 continue;
             }
 
-                        var subitemSentence = NormalizeSentence(child.SentenceText, child.ItemTitle);
+            var subitemSentence = NormalizeSentence(child.SentenceText, child.ItemTitle);
             e.Add(new XElement("Subitem1", new XAttribute("Num", child.Number), new XElement("Subitem1Title", child.ItemTitle), new XElement("Subitem1Sentence", new XElement("Sentence", new XAttribute("Num", 1), subitemSentence))));
         }
 
@@ -105,16 +108,12 @@ public sealed class LawXmlRenderer
                 new XElement("Sentence", new XAttribute("Num", 1), rawListItem.SentenceText)));
     }
 
-    private static XElement RenderRawBulletItem(ItemNode i, LawXmlRenderOptions options)
+    private static XElement RenderRawBulletAsUntitledItem(ItemNode rawListItem, int num)
     {
-        var itemTitle = string.IsNullOrWhiteSpace(i.ItemTitle)
-            ? JapaneseNumberFormatter.ToItemTitle(i.Number, options.ArabicNumbers)
-            : i.ItemTitle;
         return new XElement("Item",
-            new XAttribute("Num", i.Number),
-            new XElement("ItemTitle", itemTitle),
-            new XElement("ItemSentence", new XElement("Sentence", new XAttribute("Num", 1))),
-            RenderList(i));
+            new XAttribute("Num", num),
+            new XElement("ItemSentence",
+                new XElement("Sentence", new XAttribute("Num", 1), rawListItem.SentenceText)));
     }
 
     private static IEnumerable<XElement> RenderSupplementaryProvisions(LawDocumentModel model)

--- a/tests/Zuke.Core.Tests/XsdValidationTests.cs
+++ b/tests/Zuke.Core.Tests/XsdValidationTests.cs
@@ -117,10 +117,12 @@ lang: ja
     }
 
     [Fact]
-    public void IkujiKaigoLawtext_GeneratesValidXml_WithOfficialXsd()
+    public void IkujiKaigoLawtextImport_PassesOfficialXsdRoundTripCheck()
     {
         var source = File.ReadAllText(Path.Combine(TestHelpers.RepoRoot, "samples", "ikuji_kaigo_kyugyo_kitei_lawtext.txt"));
         var imported = new LawtextImportService().Import(source, "samples/ikuji_kaigo_kyugyo_kitei_lawtext.txt", new());
+        Assert.False(imported.HasErrors);
+        Assert.DoesNotContain(imported.Diagnostics, d => d.Code == "LMD044");
 
         var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "samples/ikuji_kaigo_kyugyo_kitei_lawtext.imported.md", new CompileOptions(false, true));
         Assert.False(compiled.HasErrors);
@@ -133,22 +135,68 @@ lang: ja
     }
 
     [Fact]
-    public void RawBulletList_GeneratesValidXml_WithOfficialXsd()
+    public void ParagraphRawBullet_GeneratesValidXml_WithOfficialXsd()
     {
-        const string lawtext = """
-箇条書きテスト規程
+        const string markdown = """
+---
+lawTitle: テスト規則
+lawNum: テスト第1号
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+# テスト規則
 
-第1条　次の事項を定める。
-  - 勤務区分A
-  - 勤務区分B
+## 第一条
+本文。
+  - 通常勤務=...
+  - 時差出勤A=...
 """;
-        var imported = new LawtextImportService().Import(lawtext, "raw-bullet.law.txt", new());
-        var compiled = new LawMarkdownCompiler().Compile(imported.Markdown, "raw-bullet.imported.md", new CompileOptions(false, true));
+        var compiled = new LawMarkdownCompiler().Compile(markdown, "paragraph-raw-bullet.md", new CompileOptions(false, true));
         Assert.False(compiled.HasErrors);
 
         var xml = new LawXmlRenderer().Render(compiled.Document!.Document);
         var xmlText = xml.ToString(SaveOptions.DisableFormatting);
-        Assert.Contains("<List>", xmlText);
+        Assert.DoesNotContain("<Paragraph Num=\"1\"><ParagraphNum /><ParagraphSentence><Sentence Num=\"1\">本文。</Sentence></ParagraphSentence><List>", xmlText);
+        Assert.Contains("<Item Num=\"1\"><ItemSentence><Sentence Num=\"1\">通常勤務=...</Sentence></ItemSentence></Item>", xmlText);
+        Assert.Contains("<Item Num=\"2\"><ItemSentence><Sentence Num=\"1\">時差出勤A=...</Sentence></ItemSentence></Item>", xmlText);
+        Assert.DoesNotContain("<Subitem1Title>-</Subitem1Title>", xmlText);
+
+        var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");
+        var diags = new LawXmlValidator().Validate(xml, xsd);
+        Assert.DoesNotContain(diags, d => d.Code == "LMD044");
+    }
+
+    [Fact]
+    public void ItemRawBullet_GeneratesValidXml_WithOfficialXsd()
+    {
+        const string markdown = """
+---
+lawTitle: テスト規則
+lawNum: テスト第1号
+era: Reiwa
+year: 6
+num: 1
+lawType: Misc
+lang: ja
+---
+# テスト規則
+
+## 第一条
+本文。
+  一　対象従業員は...
+    - 通常勤務=...
+    - 時差出勤A=...
+""";
+        var compiled = new LawMarkdownCompiler().Compile(markdown, "item-raw-bullet.md", new CompileOptions(false, true));
+        Assert.False(compiled.HasErrors);
+
+        var xml = new LawXmlRenderer().Render(compiled.Document!.Document);
+        var xmlText = xml.ToString(SaveOptions.DisableFormatting);
+        Assert.Contains("<Item Num=\"1\">", xmlText);
+        Assert.DoesNotContain("<Paragraph Num=\"1\"><ParagraphNum /><ParagraphSentence><Sentence Num=\"1\">本文。</Sentence></ParagraphSentence><List>", xmlText);
         Assert.DoesNotContain("<Subitem1Title>-</Subitem1Title>", xmlText);
 
         var xsd = Path.Combine(TestHelpers.RepoRoot, "schemas", "XMLSchemaForJapaneseLaw_v3.xsd");


### PR DESCRIPTION
### Motivation
- Ensure raw bullet lists inside paragraphs or items produce XML that conforms to the official XSD by representing them as untitled `<Item>` elements and applying correct numbering within the paragraph scope.

### Description
- Detect paragraph-scoped raw bullets with `p.Items.Any(i => i.IsRawBullet)` and assign sequential numbers starting at 1, passing an override to `RenderItem` via an `int? numOverride` parameter.
- Replace the old `RenderRawBulletItem` with `RenderRawBulletAsUntitledItem` which emits an `<Item Num="..."><ItemSentence>...</ItemSentence></Item>` for raw bullets instead of a `<List>` element.
- Update `RenderParagraph` to compute `outputNum` per item and call either `RenderItem` or the new raw-bullet renderer with that number.
- Modify `tests/Zuke.Core.Tests/XsdValidationTests.cs` to rename and add tests (`IkujiKaigoLawtextImport_PassesOfficialXsdRoundTripCheck`, `ParagraphRawBullet_GeneratesValidXml_WithOfficialXsd`, `ItemRawBullet_GeneratesValidXml_WithOfficialXsd`) and adjust assertions to check XML structure and XSD diagnostics.

### Testing
- Ran the unit test suite in `tests/Zuke.Core.Tests`, including the updated `XsdValidationTests`, and they all passed.
- Added assertions that verify raw bullets are emitted as `<Item Num="...">` and that `<List>` and unwanted `<Subitem1Title>-</Subitem1Title>` are not present, and these assertions succeeded.
- Performed XSD validation against `XMLSchemaForJapaneseLaw_v3.xsd` in the tests and confirmed that diagnostic `LMD044` is not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d36908c483288f5d0d3c96998adb)