### PR TITLE
Use ordinal comparison for paragraph number assertions in tests

### DIFF
--- a/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
+++ b/tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs
@@ -40,7 +40,7 @@ public class LawtextImportRegressionTests
         Assert.DoesNotContain("本条第5条第1項", rendered);
         Assert.Contains("会社は、本条第6項又は第7項を準用する。", rendered);
         Assert.Contains("従業員は、本条第3項第1号による。", rendered);
-        Assert.DoesNotContain("\n２　会社は", rendered);
+        Assert.DoesNotContain("\n２　会社は", rendered, StringComparison.Ordinal);
         Assert.Contains("\n      附則\n", rendered);
     }
 

--- a/tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs
+++ b/tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs
@@ -66,9 +66,9 @@ paragraphNumberStyle: ascii
 
         var rendered = new LawtextRenderer().Render(compiled.Document!);
 
-        Assert.Contains("\n2　会社は", rendered);
-        Assert.Contains("\n3　従業員は", rendered);
-        Assert.DoesNotContain("\n２　会社は", rendered);
-        Assert.DoesNotContain("\n３　従業員は", rendered);
+        Assert.Contains("\n2　会社は", rendered, StringComparison.Ordinal);
+        Assert.Contains("\n3　従業員は", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n２　会社は", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n３　従業員は", rendered, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent locale-dependent false negatives where culture-sensitive string comparisons treat fullwidth digits (e.g. "２") as equivalent to ASCII digits (e.g. "2") in paragraph-number assertions.

### Description
- Updated assertions to use ordinal comparison (`StringComparison.Ordinal`) in `tests/Zuke.Core.Tests/ParagraphNumberStyleTests.cs` and `tests/Zuke.Core.Tests/LawtextImportRegressionTests.cs` so positive and negative checks compare bytes rather than use current culture.

### Testing
- Ran `dotnet build -c Release`, `dotnet test -c Release`, and `dotnet pack -c Release`, and all commands completed successfully; targeted tests including `ParagraphNumberStyleTests.MarkdownRoundTrip_PreservesAsciiParagraphNumbers` and `LawtextImportRegressionTests.RoundTrip_FixesKnownResidualBugs` passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48f62fedc83289c578dd2ce2b1ae0)