### PR TITLE
Add NuGet release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: NuGet Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Display .NET info
+        run: dotnet --info
+
+      - name: Restore
+        run: dotnet restore zuke.sln
+
+      - name: Build
+        run: dotnet build zuke.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test zuke.sln --configuration Release --no-build --verbosity normal
+
+      - name: Pack global tool
+        run: dotnet pack src/Zuke.Cli/Zuke.Cli.csproj --configuration Release --no-build -o ./nupkg
+
+      - name: Publish to NuGet.org
+        run: dotnet nuget push "./nupkg/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "$NUGET_API_KEY" --skip-duplicate
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Add a GitHub Actions workflow that publishes Zuke.Cli to NuGet.org when a v* tag is pushed.