### PR TITLE
MCP MVP: package Zuke.Mcp as dotnet tool, add doctor, XSD validation, and align responses

### DIFF
--- a/docs/mcp-mvp.md
+++ b/docs/mcp-mvp.md
@@ -1,15 +1,53 @@
 # Zuke.Mcp MVP
 
-`Zuke.Mcp` は Zuke のコア変換機能を MCP ツールとして公開する最小実装です。
+`Zuke.Mcp` は Zuke のコア変換機能を MCP ツールとして公開する最小実装です。現時点では **compile/lawtext/xml/doctor のみ対応** し、import / audit / diff は未対応です。
+
+## インストール
+
+```bash
+dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.1
+```
+
+ローカル `.nupkg` を使う場合:
+
+```bash
+dotnet tool install --global Zuke.Mcp --add-source ./nupkg --version 0.1.0-preview.1
+```
+
+## 起動方法
+
+`dotnet tool` インストール後、MCP サーバーは次で起動できます。
+
+```bash
+zuke-mcp
+```
+
+トランスポートは `stdio` 固定です。
 
 ## 提供ツール
 
-- `zuke.compile_lawtext`
-  - 入力: `markdown`, `strict` (既定 `false`), `numberStyle` (`kanji` / `arabic`)
-  - 出力: `lawtext`, `diagnostics`, `hasErrors`
-- `zuke.compile_xml`
-  - 入力: `markdown`, `strict` (既定 `false`), `numberStyle` (`kanji` / `arabic`), `metadataProfile` (`default` / `internal-rule`)
-  - 出力: `xml`, `diagnostics`, `hasErrors`
+- `zuke.compile_lawtext`（既存互換）
+- `zuke.compile_xml`（既存互換）
+- `zuke_lawtext`（Issue #40 名称エイリアス）
+- `zuke_convert`（Issue #40 名称エイリアス）
+- `zuke_doctor`
+
+## 共通レスポンス形式
+
+各ツールは以下を含む構造化レスポンスを返します。
+
+- `success`
+- `summary`
+- `diagnostics`
+- `outputs` または `content`
+- `hasErrors`
+
+## XSD 検証の扱い
+
+- `compile_xml` / `zuke_convert` は既定で XSD 検証を実行します。
+- `ZukeXsdProvider.ResolveDefaultPath()` で既定 XSD パスを解決し、`LawXmlValidator` で検証します。
+- XSD 不適合は `diagnostics` にエラーとして格納され、`success` / `hasErrors` に反映されます。
+- `zuke_doctor` で XSD 解決可否と解決先パスを確認できます。
 
 ## セキュリティ制約
 
@@ -20,16 +58,10 @@ MVP では以下を満たします。
 - 外部プロセス実行やネットワークアクセスを行わない。
 - 失敗時は例外スタックを返さず、診断情報を構造化して返す。
 
-## 検証手順
+## 現時点の未対応範囲
 
-1. `dotnet build zuke.sln`
-2. `dotnet test tests/Zuke.Core.Tests/Zuke.Core.Tests.csproj`
-3. MCP ホスト起動確認: `dotnet run --project src/Zuke.Mcp/Zuke.Mcp.csproj`
+以下は次段階で対応予定です。
 
-## SDK 選定
-
-`ModelContextProtocol` (公式 C# SDK) を採用。
-
-- 公式実装のため MCP 仕様追従コストが低い。
-- `WithStdioServerTransport` と attribute ベースの tool 定義で MVP 実装を短期間に作成できる。
-- .NET Generic Host / DI と統合され、将来の認証・フィルタ拡張にも接続しやすい。
+- `import`
+- `audit`
+- `diff`

--- a/src/Zuke.Mcp/Program.cs
+++ b/src/Zuke.Mcp/Program.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ModelContextProtocol.Server;
@@ -6,6 +8,7 @@ using Zuke.Core.Compilation;
 using Zuke.Core.Markdown;
 using Zuke.Core.Model;
 using Zuke.Core.Rendering;
+using Zuke.Core.Validation;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services
@@ -19,22 +22,57 @@ await builder.Build().RunAsync();
 public sealed class ZukeMcpTools
 {
     [McpServerTool(Name = "zuke.compile_lawtext"), Description("Compile markdown text to Lawtext.")]
-    public static CompileToolResponse CompileLawtext(string markdown, bool strict = false, string numberStyle = "kanji")
+    public static ToolResponse CompileLawtext(string markdown, bool strict = false, string numberStyle = "kanji")
+        => Compile(markdown, "lawtext", strict, numberStyle);
+
+    [McpServerTool(Name = "zuke_lawtext"), Description("Compile markdown text to Lawtext.")]
+    public static ToolResponse Lawtext(string markdown, bool strict = false, string numberStyle = "kanji")
         => Compile(markdown, "lawtext", strict, numberStyle);
 
     [McpServerTool(Name = "zuke.compile_xml"), Description("Compile markdown text to Japanese law XML.")]
-    public static CompileToolResponse CompileXml(string markdown, bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
+    public static ToolResponse CompileXml(string markdown, bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
         => Compile(markdown, "xml", strict, numberStyle, metadataProfile);
 
-    private static CompileToolResponse Compile(string markdown, string output, bool strict, string numberStyle, string metadataProfile = "default")
+    [McpServerTool(Name = "zuke_convert"), Description("Compile markdown text to Japanese law XML.")]
+    public static ToolResponse Convert(string markdown, bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
+        => Compile(markdown, "xml", strict, numberStyle, metadataProfile);
+
+    [McpServerTool(Name = "zuke_doctor"), Description("Show MCP runtime diagnostics and environment information.")]
+    public static ToolResponse Doctor()
+    {
+        var xsdPath = ZukeXsdProvider.ResolveDefaultPath();
+        var xsdResolved = File.Exists(xsdPath);
+        var outputs = new Dictionary<string, object?>
+        {
+            ["version"] = typeof(ZukeMcpTools).Assembly.GetName().Version?.ToString(),
+            ["workingDirectory"] = Directory.GetCurrentDirectory(),
+            ["xsdResolved"] = xsdResolved,
+            ["xsdPath"] = xsdPath,
+            ["runtime"] = RuntimeInformation.FrameworkDescription,
+            ["osDescription"] = RuntimeInformation.OSDescription,
+            ["processArchitecture"] = RuntimeInformation.ProcessArchitecture.ToString()
+        };
+        var diagnostics = xsdResolved
+            ? Array.Empty<ToolDiagnostic>()
+            : new[] { new ToolDiagnostic("error", "MCP001", "XSD file was not found at resolved path.", xsdPath) };
+
+        return BuildResponse(
+            success: xsdResolved,
+            summary: xsdResolved ? "Environment is healthy." : "Environment has configuration issues.",
+            diagnostics: diagnostics,
+            outputs: outputs,
+            content: null);
+    }
+
+    private static ToolResponse Compile(string markdown, string output, bool strict, string numberStyle, string metadataProfile = "default")
     {
         var arabic = string.Equals(numberStyle, "arabic", StringComparison.OrdinalIgnoreCase);
         var requireFrontMatter = output == "xml";
         var result = new LawMarkdownCompiler().Compile(markdown, filePath: null, new CompileOptions(strict, arabic, requireFrontMatter));
-        var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToArray();
+        var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToList();
         if (result.HasErrors || result.Document is null)
         {
-            return new CompileToolResponse(null, null, diagnostics, true);
+            return BuildResponse(false, "Compilation failed.", diagnostics, null, null);
         }
 
         if (string.Equals(output, "lawtext", StringComparison.OrdinalIgnoreCase))
@@ -42,13 +80,35 @@ public sealed class ZukeMcpTools
             var frontMatter = FrontMatterParser.ParseDetailed(markdown);
             var model = ApplyLawtextMetadataFallback(result.Document.Document, frontMatter);
             var lawtext = new LawtextRenderer().Render(result.Document with { Document = model }, LawtextRenderOptions.Default with { ArabicNumbers = arabic });
-            var renderDiagnostics = LawtextRenderer.ValidateRenderedText(lawtext).Select(ToDiagnostic).ToArray();
-            return new CompileToolResponse(lawtext, null, diagnostics.Concat(renderDiagnostics).ToArray(), renderDiagnostics.Any(x => x.Severity == "error"));
+            var renderDiagnostics = LawtextRenderer.ValidateRenderedText(lawtext).Select(ToDiagnostic);
+            diagnostics.AddRange(renderDiagnostics);
+            var hasErrors = diagnostics.Any(x => x.Severity == "error");
+            return BuildResponse(!hasErrors, hasErrors ? "Lawtext generation failed." : "Lawtext generated successfully.", diagnostics, new Dictionary<string, object?> { ["lawtext"] = lawtext }, lawtext);
         }
 
         var xmlModel = ApplyMetadataProfile(result.Document.Document, metadataProfile);
         var xml = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = arabic }).ToString();
-        return new CompileToolResponse(null, xml, diagnostics, false);
+
+        var xsdPath = ZukeXsdProvider.ResolveDefaultPath();
+        if (File.Exists(xsdPath))
+        {
+            var xmlDocument = XDocument.Parse(xml);
+            var xsdDiagnostics = new LawXmlValidator().Validate(xmlDocument, xsdPath).Select(ToDiagnostic);
+            diagnostics.AddRange(xsdDiagnostics);
+        }
+        else
+        {
+            diagnostics.Add(new ToolDiagnostic("error", "MCP001", "XSD file was not found; XML validation was not run.", xsdPath));
+        }
+
+        var xmlHasErrors = diagnostics.Any(x => x.Severity == "error");
+        return BuildResponse(!xmlHasErrors, xmlHasErrors ? "XML generation failed validation." : "XML generated and validated successfully.", diagnostics, new Dictionary<string, object?> { ["xml"] = xml, ["xsdPath"] = xsdPath }, xml);
+    }
+
+    private static ToolResponse BuildResponse(bool success, string summary, IReadOnlyList<ToolDiagnostic> diagnostics, IReadOnlyDictionary<string, object?>? outputs, string? content)
+    {
+        var hasErrors = diagnostics.Any(x => x.Severity == "error");
+        return new ToolResponse(success && !hasErrors, summary, diagnostics, outputs, content, hasErrors);
     }
 
     private static LawDocumentModel ApplyLawtextMetadataFallback(LawDocumentModel model, FrontMatterParseResult frontMatter)
@@ -87,4 +147,10 @@ public sealed class ZukeMcpTools
 
 public sealed record ToolDiagnostic(string Severity, string Code, string Message, string? Location);
 
-public sealed record CompileToolResponse(string? Lawtext, string? Xml, IReadOnlyList<ToolDiagnostic> Diagnostics, bool HasErrors);
+public sealed record ToolResponse(
+    bool Success,
+    string Summary,
+    IReadOnlyList<ToolDiagnostic> Diagnostics,
+    IReadOnlyDictionary<string, object?>? Outputs,
+    string? Content,
+    bool HasErrors);

--- a/src/Zuke.Mcp/Zuke.Mcp.csproj
+++ b/src/Zuke.Mcp/Zuke.Mcp.csproj
@@ -1,4 +1,25 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>zuke-mcp</ToolCommandName>
+    <PackageId>Zuke.Mcp</PackageId>
+    <Version>0.1.0-preview.1</Version>
+    <Authors>Takashi U</Authors>
+    <Company>Takashi-U</Company>
+    <Description>Zuke MCP server for lawtext/XML compilation and validation.</Description>
+    <PackageTags>law;lawtext;japanese-law;markdown;xml;mcp;dotnet-tool</PackageTags>
+    <RepositoryUrl>https://github.com/Takashi-U/zuke</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Zuke.Core\Zuke.Core.csproj" />
@@ -9,11 +30,11 @@
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="/" />
+    <None Include="../../LICENSE" Pack="true" PackagePath="/" />
+    <None Include="../../ThirdPartyNotices.md" Pack="true" PackagePath="/" />
+    <None Include="../../schemas/XMLSchemaForJapaneseLaw_v3.xsd" Pack="true" PackagePath="schemas/" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Motivation

- Make `Zuke.Mcp` distributable as a .NET global tool and match packaging behavior of `Zuke.Cli` so the MCP server can be installed and run via `dotnet tool`.
- Provide the MVP features required by Issue #40: a common structured MCP response format, XSD validation for XML outputs, and runtime diagnostics via a `doctor` tool.
- Clarify current MVP scope in documentation and ensure packaged assets (README/LICENSE/ThirdPartyNotices/XSD) are included for tool consumers.

### Description

- Updated `src/Zuke.Mcp/Zuke.Mcp.csproj` to publish as a dotnet global tool with `PackAsTool`, `ToolCommandName` = `zuke-mcp`, `PackageId` = `Zuke.Mcp`, `Version` = `0.1.0-preview.1`, `PackageReadmeFile`, `PackageLicenseExpression` = `MIT`, `TreatWarningsAsErrors`, and added `README.md`, `LICENSE`, `ThirdPartyNotices.md`, and `schemas/XMLSchemaForJapaneseLaw_v3.xsd` to the package payload.
- Refactored MCP tool responses to a common structured format `ToolResponse` containing `success`, `summary`, `diagnostics`, `outputs`/`content`, and `hasErrors`, and introduced `ToolDiagnostic` for output diagnostics.
- Added Issue #40 compatible tool names and aliases: `zuke_lawtext` (alias for lawtext), `zuke_convert` (alias for xml), and new `zuke_doctor` which returns version, working directory, XSD resolution status and path, and runtime/OS/architecture info.
- Implemented default XSD validation in the XML compile flow using `ZukeXsdProvider.ResolveDefaultPath()` and `LawXmlValidator`, returning XSD nonconformance as diagnostics and reflecting validation result in `success`/`hasErrors`.
- Updated `docs/mcp-mvp.md` with install/run instructions (`dotnet tool install --global Zuke.Mcp`), supported tools (currently `compile/lawtext/xml/doctor` only), XSD behavior, security constraints, and note that `import/audit/diff` are not yet supported.

### Testing

- Ran restore and build: `dotnet restore ./zuke.sln` and `dotnet build ./zuke.sln -c Release`, which completed successfully.
- Ran tests: `dotnet test ./zuke.sln -c Release`, all tests passed (`192` tests passed in the test run).
- Packaged the tool: `dotnet pack ./src/Zuke.Mcp/Zuke.Mcp.csproj -c Release -o ./nupkg`, which produced `Zuke.Mcp.0.1.0-preview.1.nupkg` successfully.
- Local install and startup: `dotnet tool install --global Zuke.Mcp --add-source ./nupkg --version 0.1.0-preview.1` succeeded and `zuke-mcp` startup was confirmed (stdio server lifecycle logs observed via a short timeout run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58dea953c832880aac44e9794c2dd)