### PR TITLE
Fix Zuke.Mcp stdio logging so stdout stays JSON-RPC clean

### DIFF
--- a/src/Zuke.Mcp/Program.cs
+++ b/src/Zuke.Mcp/Program.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using Zuke.Core.Compilation;
 using Zuke.Core.Markdown;
@@ -11,6 +12,16 @@ using Zuke.Core.Rendering;
 using Zuke.Core.Validation;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(options =>
+{
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+builder.Logging.AddFilter("Microsoft", LogLevel.Warning);
+builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
+builder.Logging.AddFilter("ModelContextProtocol", LogLevel.Warning);
+
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()


### PR DESCRIPTION
### Motivation
- When `zuke-mcp` runs as an MCP stdio server, info logs emitted by .NET Generic Host / `ModelContextProtocol` were written to stdout and broke MCP JSON-RPC framing so Codex Desktop could not recognize the server and tools were not exposed.

### Description
- Add `Microsoft.Extensions.Logging` and reconfigure logging immediately after `Host.CreateApplicationBuilder(args)` to explicitly control providers and routing.
- Clear default providers and add the console logger with `LogToStandardErrorThreshold = LogLevel.Trace` so console output is sent to `stderr` instead of `stdout`.
- Set the default minimum log level to `Warning` and add category filters for `Microsoft`, `Microsoft.Hosting.Lifetime`, and `ModelContextProtocol` to prevent `info` logs from leaking into `stdout`.
- Preserve MCP tool response behavior (no `Console.WriteLine` use) so doctor/convert/compile results are returned as MCP tool responses rather than printed to stdout.

### Testing
- Ran `dotnet restore ./zuke.sln` and it completed successfully.
- Ran `dotnet build ./zuke.sln -c Release` and the build succeeded with no errors.
- Ran `dotnet test ./zuke.sln -c Release` and tests passed (`192` tests passed in this environment).
- Ran `dotnet pack ./src/Zuke.Mcp/Zuke.Mcp.csproj -c Release -o ./nupkg` and successfully installed the produced package as a global tool from the local `nupkg`, and a quick startup sanity check showed `STDOUT_LINES:0`; full Codex Desktop registration / UI verification of tool visibility remains pending in a non-headless environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ce1cdde88328b1d10fd26afc5a28)