### PR TITLE
Improve Zuke.Mcp README coverage and NuGet readme packaging

### DIFF
--- a/README.Mcp.md
+++ b/README.Mcp.md
@@ -1,0 +1,80 @@
+# Zuke.Mcp
+
+`Zuke.Mcp` は、[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 対応の AI アプリから、法令標準 XML 変換・Lawtext 変換・診断を安全に呼び出すための .NET グローバルツールです。
+
+- 対象: Codex Desktop などの MCP ホスト
+- 位置づけ: `Zuke.Cli` とは別パッケージ（MCP サーバー専用）
+- トランスポート: `stdio`（MCP JSON-RPC）
+
+## インストール
+
+```powershell
+dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.2
+```
+
+起動:
+
+```powershell
+zuke-mcp
+```
+
+## Codex Desktop 等の MCP ホスト設定例
+
+Windows の例（Codex Desktop 設定ファイル）:
+
+```toml
+[mcp_servers.zuke]
+command = 'C:\Users\<USER>\.dotnet\tools\zuke-mcp.exe'
+args = []
+```
+
+> 補足: `command` は環境に応じて実際のインストール先パスに合わせてください。
+
+## 提供ツール一覧（MVP）
+
+- `zuke_convert`（Markdown/Lawtext -> 法令標準 XML）
+- `zuke_lawtext`（法令標準 XML -> Lawtext）
+- `zuke_doctor`（実行環境・XSD 解決可否の確認）
+- `zuke.compile_lawtext`（既存互換）
+- `zuke.compile_xml`（既存互換）
+
+## `zuke_doctor` の確認方法
+
+MCP ホストから `zuke_doctor` を実行し、以下を確認してください。
+
+- `success` が `true`
+- `hasErrors` が `false`
+- `summary` にエラーがないこと
+- `outputs` / `diagnostics` に XSD 解決失敗が出ていないこと
+
+## `zuke_lawtext` / `zuke_convert` の利用例
+
+### 例1: `zuke_lawtext`
+
+- 入力: 法令標準 XML 文字列
+- 出力: Lawtext 文字列（`content` または `outputs`）
+
+### 例2: `zuke_convert`
+
+- 入力: Markdown または Lawtext 文字列
+- 出力: 法令標準 XML 文字列（`content` または `outputs`）
+- 補足: 既定で XSD 検証を実行し、問題は `diagnostics` に格納されます
+
+## stdout の取り扱い（重要）
+
+`Zuke.Mcp` は **stdout を MCP JSON-RPC 専用**として扱います。プロトコル破損を防ぐため、ログを stdout に出力しない設計です。
+
+- 通信: stdout（JSON-RPC メッセージ）
+- ログ/診断: 構造化レスポンス（`diagnostics` 等）で返却
+
+## 現時点の未対応範囲
+
+MVP では以下は未対応です。
+
+- `import`
+- `audit`
+- `diff`
+
+## 免責・人間確認
+
+本ツールは法令・規程の技術的変換と診断を支援するものであり、法的判断を代替しません。公開・施行・運用に関わる最終判断は、必ず人間（法務・実務担当者）が原文・出力物を確認した上で行ってください。

--- a/README.md
+++ b/README.md
@@ -522,5 +522,42 @@ zuke 本体は MIT License で提供します。詳細は `LICENSE` を参照し
 
 ## MCP (MVP)
 
-`src/Zuke.Mcp` に MCP サーバー MVP を追加しました。詳細は `docs/mcp-mvp.md` を参照してください。
+`Zuke.Mcp` は、MCP（Model Context Protocol）対応の AI アプリ（Codex Desktop など）から Zuke の変換機能を使うための**別パッケージ**です。CLI 用の `Zuke.Cli` とは用途と配布先（NuGet パッケージページ）が異なります。
 
+### インストール
+
+```powershell
+dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.2
+```
+
+### 起動
+
+```powershell
+zuke-mcp
+```
+
+### Codex Desktop / MCP ホスト設定例
+
+```toml
+[mcp_servers.zuke]
+command = 'C:\Users\<USER>\.dotnet\tools\zuke-mcp.exe'
+args = []
+```
+
+### 提供ツール（MVP）
+
+- `zuke_convert`
+- `zuke_lawtext`
+- `zuke_doctor`
+- `zuke.compile_lawtext`（既存互換）
+- `zuke.compile_xml`（既存互換）
+
+### 現時点の未対応範囲
+
+以下は現時点で未対応です。
+
+- `import`
+- `audit`
+- `diff`
+
+詳細は `docs/mcp-mvp.md` を参照してください。

--- a/docs/mcp-mvp.md
+++ b/docs/mcp-mvp.md
@@ -4,21 +4,21 @@
 
 ## インストール
 
-```bash
-dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.1
+```powershell
+dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.2
 ```
 
 ローカル `.nupkg` を使う場合:
 
-```bash
-dotnet tool install --global Zuke.Mcp --add-source ./nupkg --version 0.1.0-preview.1
+```powershell
+dotnet tool install --global Zuke.Mcp --add-source ./nupkg --version 0.1.0-preview.2
 ```
 
 ## 起動方法
 
 `dotnet tool` インストール後、MCP サーバーは次で起動できます。
 
-```bash
+```powershell
 zuke-mcp
 ```
 

--- a/src/Zuke.Mcp/Zuke.Mcp.csproj
+++ b/src/Zuke.Mcp/Zuke.Mcp.csproj
@@ -13,7 +13,7 @@
     <PackageTags>law;lawtext;japanese-law;markdown;xml;mcp;dotnet-tool</PackageTags>
     <RepositoryUrl>https://github.com/Takashi-U/zuke</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.Mcp.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="/" />
+    <None Include="../../README.Mcp.md" Pack="true" PackagePath="/" />
     <None Include="../../LICENSE" Pack="true" PackagePath="/" />
     <None Include="../../ThirdPartyNotices.md" Pack="true" PackagePath="/" />
     <None Include="../../schemas/XMLSchemaForJapaneseLaw_v3.xsd" Pack="true" PackagePath="schemas/" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
### Motivation

- リポジトリの現行 `README.md` は MCP（Zuke.Mcp）の導入・設定例が簡潔すぎて NuGet 上や利用者にとって分かりにくかったため改善する必要がありました。 
- `src/Zuke.Mcp/Zuke.Mcp.csproj` が `PackageReadmeFile` に `README.md` を指定しているため NuGet では CLI 向けの README が表示されており、MCP 専用の説明を別に用意する必要がありました。 
- MCP 用ドキュメントとパッケージメタデータを整合させて利用者がすぐに設定できる状態にすることが目的です。

### Description

- `README.md` の「MCP (MVP)」節を拡充し `Zuke.Mcp` が別パッケージである旨、`dotnet tool install` の `0.1.0-preview.2` 例、`zuke-mcp` 起動例、Codex Desktop 用の MCP ホスト設定例、提供ツール一覧および未対応範囲への言及を追加しました。 
- リポジトリ直下に MCP 専用の NuGet README として日本語の `README.Mcp.md` を新規追加し、インストール・起動・MCP 設定例・提供ツール・`zuke_doctor` 確認方法・利用例・stdout の設計方針・未対応範囲・免責を記載しました。 
- `src/Zuke.Mcp/Zuke.Mcp.csproj` の `PackageReadmeFile` を `README.Mcp.md` に変更し、`README.Mcp.md` をパッケージのルートに含めるよう `None Include` を追加しつつ既存の `README.md` / `LICENSE` / `ThirdPartyNotices.md` / XSD の同梱設定は維持しました。 
- `docs/mcp-mvp.md` のコマンド例を PowerShell ブロックに揃え、`0.1.0-preview.1` の表記を `0.1.0-preview.2` に更新しました。

### Testing

- 実行した自動化コマンドは `dotnet restore ./zuke.sln` で成功しました。 
- 実行した自動化コマンドは `dotnet build ./zuke.sln -c Release` で成功しました。 
- 実行した自動化コマンドは `dotnet test ./zuke.sln -c Release` で全テストが通り（Passed: 192 / Failed: 0）成功しました。 
- 実行した自動化コマンドは `dotnet pack ./src/Zuke.Mcp/Zuke.Mcp.csproj -c Release -o ./nupkg` で `Zuke.Mcp.0.1.0-preview.2.nupkg` が生成され、パッケージ内に `README.Mcp.md` がルートに存在することと `.nuspec` の `<readme>` が `README.Mcp.md` になっていることを検証して確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d468c9ec8328858013ba75898ca2)