### PR TITLE
Add string-safe MCP tools: import/audit/diff/validate and extend zuke_convert

### DIFF
--- a/README.Mcp.md
+++ b/README.Mcp.md
@@ -1,80 +1,38 @@
 # Zuke.Mcp
 
-`Zuke.Mcp` は、[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 対応の AI アプリから、法令標準 XML 変換・Lawtext 変換・診断を安全に呼び出すための .NET グローバルツールです。
+`Zuke.Mcp` は、MCP ホスト（Codex Desktop など）から Zuke.Core の主要変換機能を **文字列入力・文字列出力** で安全に呼び出すための .NET ツールです。
 
-- 対象: Codex Desktop などの MCP ホスト
-- 位置づけ: `Zuke.Cli` とは別パッケージ（MCP サーバー専用）
-- トランスポート: `stdio`（MCP JSON-RPC）
+- `Zuke.Cli` には依存せず、`Zuke.Core` を直接利用
+- トランスポートは `stdio`（MCP JSON-RPC）
+- stdout は JSON-RPC 専用（`Console.WriteLine` などで汚さない）
+- ファイル I/O / 任意コマンド実行 / Git / ネットワーク操作ツールは未提供
 
-## インストール
+## 提供ツール
 
-```powershell
-dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.2
-```
-
-起動:
-
-```powershell
-zuke-mcp
-```
-
-## Codex Desktop 等の MCP ホスト設定例
-
-Windows の例（Codex Desktop 設定ファイル）:
-
-```toml
-[mcp_servers.zuke]
-command = 'C:\Users\<USER>\.dotnet\tools\zuke-mcp.exe'
-args = []
-```
-
-> 補足: `command` は環境に応じて実際のインストール先パスに合わせてください。
-
-## 提供ツール一覧（MVP）
-
-- `zuke_convert`（Markdown/Lawtext -> 法令標準 XML）
-- `zuke_lawtext`（法令標準 XML -> Lawtext）
-- `zuke_doctor`（実行環境・XSD 解決可否の確認）
+- `zuke_import`（Lawtext → 拡張 Markdown）
+- `zuke_audit`（Lawtext 監査）
+- `zuke_diff`（Markdown 同士を Lawtext 正規化して unified diff 生成）
+- `zuke_validate_xml`（XML を同梱 XSD で検証）
+- `zuke_convert`（`to=xml|lawtext|both`）
+- `zuke_lawtext`（既存互換）
+- `zuke_doctor`
 - `zuke.compile_lawtext`（既存互換）
 - `zuke.compile_xml`（既存互換）
 
-## `zuke_doctor` の確認方法
+## MCP ホストからの自然言語利用例
 
-MCP ホストから `zuke_doctor` を実行し、以下を確認してください。
+- 「この Lawtext を zuke_import で Markdown に変換して」
+- 「この Lawtext を zuke_audit で strict=true で監査して、reportMarkdown も返して」
+- 「この old/new Markdown を zuke_diff で比較して（context=5）」
+- 「この XML を zuke_validate_xml で検証して」
+- 「この Markdown を zuke_convert で to=both にして XML と Lawtext 両方出して」
 
-- `success` が `true`
-- `hasErrors` が `false`
-- `summary` にエラーがないこと
-- `outputs` / `diagnostics` に XSD 解決失敗が出ていないこと
+## 診断コード
 
-## `zuke_lawtext` / `zuke_convert` の利用例
+- `MCP004`: unsupported option or mode
+- `MCP005`: XSD cannot be resolved
+- `MCP999`: unexpected exception
 
-### 例1: `zuke_lawtext`
+## 免責
 
-- 入力: 法令標準 XML 文字列
-- 出力: Lawtext 文字列（`content` または `outputs`）
-
-### 例2: `zuke_convert`
-
-- 入力: Markdown または Lawtext 文字列
-- 出力: 法令標準 XML 文字列（`content` または `outputs`）
-- 補足: 既定で XSD 検証を実行し、問題は `diagnostics` に格納されます
-
-## stdout の取り扱い（重要）
-
-`Zuke.Mcp` は **stdout を MCP JSON-RPC 専用**として扱います。プロトコル破損を防ぐため、ログを stdout に出力しない設計です。
-
-- 通信: stdout（JSON-RPC メッセージ）
-- ログ/診断: 構造化レスポンス（`diagnostics` 等）で返却
-
-## 現時点の未対応範囲
-
-MVP では以下は未対応です。
-
-- `import`
-- `audit`
-- `diff`
-
-## 免責・人間確認
-
-本ツールは法令・規程の技術的変換と診断を支援するものであり、法的判断を代替しません。公開・施行・運用に関わる最終判断は、必ず人間（法務・実務担当者）が原文・出力物を確認した上で行ってください。
+法的判断を代替するものではありません。公開・施行・運用前に必ず人間が原文・変換結果を確認してください。

--- a/docs/mcp-mvp.md
+++ b/docs/mcp-mvp.md
@@ -1,67 +1,37 @@
 # Zuke.Mcp MVP
 
-`Zuke.Mcp` は Zuke のコア変換機能を MCP ツールとして公開する最小実装です。現時点では **compile/lawtext/xml/doctor のみ対応** し、import / audit / diff は未対応です。
+`Zuke.Mcp` は Zuke.Core 機能を MCP ツールとして提供する最小実装です。
 
-## インストール
+## 現在対応している機能
 
-```powershell
-dotnet tool install --global Zuke.Mcp --version 0.1.0-preview.2
-```
+- compile/lawtext/xml/doctor
+- import
+- audit
+- diff
+- validate_xml
 
-ローカル `.nupkg` を使う場合:
-
-```powershell
-dotnet tool install --global Zuke.Mcp --add-source ./nupkg --version 0.1.0-preview.2
-```
-
-## 起動方法
-
-`dotnet tool` インストール後、MCP サーバーは次で起動できます。
-
-```powershell
-zuke-mcp
-```
-
-トランスポートは `stdio` 固定です。
+すべて **文字列入力・文字列出力** で動作し、ファイル I/O は提供しません。
 
 ## 提供ツール
 
-- `zuke.compile_lawtext`（既存互換）
-- `zuke.compile_xml`（既存互換）
-- `zuke_lawtext`（Issue #40 名称エイリアス）
-- `zuke_convert`（Issue #40 名称エイリアス）
+- `zuke_import`
+- `zuke_audit`
+- `zuke_diff`（`view=unified` のみ）
+- `zuke_validate_xml`
+- `zuke_convert`（`to=xml|lawtext|both`）
+- `zuke_lawtext`
 - `zuke_doctor`
-
-## 共通レスポンス形式
-
-各ツールは以下を含む構造化レスポンスを返します。
-
-- `success`
-- `summary`
-- `diagnostics`
-- `outputs` または `content`
-- `hasErrors`
-
-## XSD 検証の扱い
-
-- `compile_xml` / `zuke_convert` は既定で XSD 検証を実行します。
-- `ZukeXsdProvider.ResolveDefaultPath()` で既定 XSD パスを解決し、`LawXmlValidator` で検証します。
-- XSD 不適合は `diagnostics` にエラーとして格納され、`success` / `hasErrors` に反映されます。
-- `zuke_doctor` で XSD 解決可否と解決先パスを確認できます。
+- `zuke.compile_lawtext`
+- `zuke.compile_xml`
 
 ## セキュリティ制約
 
-MVP では以下を満たします。
+- `stdio` のみ（stdout は MCP JSON-RPC 専用）
+- ファイル I/O ツールなし
+- 外部プロセス実行なし
+- ネットワークアクセスなし
+- 例外時は `MCP999` で構造化返却（スタックトレース非返却）
 
-- トランスポートは `stdio` のみ（外部ポートを開かない）。
-- ファイル読み書きツールを提供しない（入力文字列のみを処理）。
-- 外部プロセス実行やネットワークアクセスを行わない。
-- 失敗時は例外スタックを返さず、診断情報を構造化して返す。
+## 既知の未対応
 
-## 現時点の未対応範囲
-
-以下は次段階で対応予定です。
-
-- `import`
-- `audit`
-- `diff`
+- `zuke_diff` の `view=html|terminal`（`MCP004` を返却）

--- a/src/Zuke.Mcp/Program.cs
+++ b/src/Zuke.Mcp/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using Zuke.Core.Compilation;
+using Zuke.Core.Diff;
+using Zuke.Core.Importing;
 using Zuke.Core.Markdown;
 using Zuke.Core.Model;
 using Zuke.Core.Rendering;
@@ -13,10 +15,7 @@ using Zuke.Core.Validation;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Logging.ClearProviders();
-builder.Logging.AddConsole(options =>
-{
-    options.LogToStandardErrorThreshold = LogLevel.Trace;
-});
+builder.Logging.AddConsole(options => { options.LogToStandardErrorThreshold = LogLevel.Trace; });
 builder.Logging.SetMinimumLevel(LogLevel.Warning);
 builder.Logging.AddFilter("Microsoft", LogLevel.Warning);
 builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
@@ -44,9 +43,86 @@ public sealed class ZukeMcpTools
     public static ToolResponse CompileXml(string markdown, bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
         => Compile(markdown, "xml", strict, numberStyle, metadataProfile);
 
-    [McpServerTool(Name = "zuke_convert"), Description("Compile markdown text to Japanese law XML.")]
-    public static ToolResponse Convert(string markdown, bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
-        => Compile(markdown, "xml", strict, numberStyle, metadataProfile);
+    [McpServerTool(Name = "zuke_convert"), Description("Compile markdown text to XML/Lawtext.")]
+    public static ToolResponse Convert(string markdown, string to = "xml", bool strict = false, string numberStyle = "kanji", string metadataProfile = "default")
+        => Compile(markdown, to, strict, numberStyle, metadataProfile);
+
+    [McpServerTool(Name = "zuke_import"), Description("Import Lawtext string to extended markdown string.")]
+    public static ToolResponse Import(string lawtext, string referenceLabels = "all", string referenceMode = "conservative", string idStyle = "ascii", string metadataMode = "frontmatter", bool strict = false, bool skipRoundtripCheck = false)
+        => SafeExecute(() =>
+        {
+            var options = new LawtextImportOptions("lawtext", referenceLabels, referenceMode, idStyle, metadataMode, strict, skipRoundtripCheck);
+            var result = new LawtextImportService().Import(lawtext, "mcp-input.law.txt", options);
+            var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToList();
+            if (result.HasErrors)
+            {
+                return BuildResponse(false, "Import failed.", diagnostics, null, null);
+            }
+
+            var outputs = new Dictionary<string, object?>
+            {
+                ["markdown"] = result.Markdown,
+                ["reportMarkdown"] = new ImportReportRenderer().Render("mcp-input.law.txt", "mcp-output.md", options, result)
+            };
+            if (result.Mapping is not null) outputs["mapping"] = result.Mapping;
+            return BuildResponse(true, "Markdown generated successfully.", diagnostics, outputs, result.Markdown);
+        });
+
+    [McpServerTool(Name = "zuke_audit"), Description("Audit Lawtext string.")]
+    public static ToolResponse Audit(string lawtext, bool strict = false, bool report = true)
+        => SafeExecute(() =>
+        {
+            var result = new LawtextAuditService().Audit(lawtext, "mcp-input.law.txt", strict);
+            var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToList();
+            var outputs = new Dictionary<string, object?>();
+            if (report) outputs["reportMarkdown"] = new LawtextAuditReportRenderer().RenderMarkdown(result);
+            return BuildResponse(!result.HasErrors, "Audit completed.", diagnostics, outputs, null);
+        });
+
+    [McpServerTool(Name = "zuke_diff"), Description("Diff two markdown strings using normalized Lawtext.")]
+    public static ToolResponse Diff(string oldMarkdown, string newMarkdown, int context = 3, string view = "unified")
+        => SafeExecute(() =>
+        {
+            if (!string.Equals(view, "unified", StringComparison.OrdinalIgnoreCase))
+            {
+                return BuildResponse(false, "Diff failed.", [new ToolDiagnostic("error", "MCP004", "Only 'unified' view is supported in MCP.", view)], null, null);
+            }
+
+            var oldCompile = new LawMarkdownCompiler().Compile(oldMarkdown, "old.md", new CompileOptions());
+            var newCompile = new LawMarkdownCompiler().Compile(newMarkdown, "new.md", new CompileOptions());
+            var diagnostics = oldCompile.Diagnostics.Concat(newCompile.Diagnostics).Select(ToDiagnostic).ToList();
+            if (oldCompile.HasErrors || newCompile.HasErrors || oldCompile.Document is null || newCompile.Document is null)
+            {
+                return BuildResponse(false, "Diff failed.", diagnostics, null, null);
+            }
+
+            var renderer = new LawtextRenderer();
+            var normalizer = new LawtextNormalizer();
+            var oldText = normalizer.Normalize(renderer.Render(oldCompile.Document, LawtextRenderOptions.Default), LawtextNormalizeOptions.Default);
+            var newText = normalizer.Normalize(renderer.Render(newCompile.Document, LawtextRenderOptions.Default), LawtextNormalizeOptions.Default);
+            var result = new LawtextDiffService().Diff(oldText, newText, new DiffOptions(context));
+            var unified = new UnifiedDiffRenderer().Render("old.md", "new.md", result);
+            var outputs = new Dictionary<string, object?> { ["diff"] = unified, ["hasChanges"] = result.HasChanges };
+            return BuildResponse(true, "Diff completed.", diagnostics, outputs, unified);
+        });
+
+    [McpServerTool(Name = "zuke_validate_xml"), Description("Validate XML string with bundled XSD.")]
+    public static ToolResponse ValidateXml(string xml)
+        => SafeExecute(() =>
+        {
+            var diagnostics = new List<ToolDiagnostic>();
+            var xsdPath = ZukeXsdProvider.ResolveDefaultPath();
+            if (!File.Exists(xsdPath))
+            {
+                diagnostics.Add(new ToolDiagnostic("error", "MCP005", "XSD file cannot be resolved.", xsdPath));
+                return BuildResponse(false, "XML validation completed.", diagnostics, new Dictionary<string, object?> { ["xsdPath"] = xsdPath, ["valid"] = false }, null);
+            }
+
+            var xmlDocument = XDocument.Parse(xml);
+            diagnostics.AddRange(new LawXmlValidator().Validate(xmlDocument, xsdPath).Select(ToDiagnostic));
+            var valid = diagnostics.All(d => d.Severity != "error");
+            return BuildResponse(valid, "XML validation completed.", diagnostics, new Dictionary<string, object?> { ["xsdPath"] = xsdPath, ["valid"] = valid }, null);
+        });
 
     [McpServerTool(Name = "zuke_doctor"), Description("Show MCP runtime diagnostics and environment information.")]
     public static ToolResponse Doctor()
@@ -65,55 +141,79 @@ public sealed class ZukeMcpTools
         };
         var diagnostics = xsdResolved
             ? Array.Empty<ToolDiagnostic>()
-            : new[] { new ToolDiagnostic("error", "MCP001", "XSD file was not found at resolved path.", xsdPath) };
+            : [new ToolDiagnostic("error", "MCP001", "XSD file was not found at resolved path.", xsdPath)];
 
-        return BuildResponse(
-            success: xsdResolved,
-            summary: xsdResolved ? "Environment is healthy." : "Environment has configuration issues.",
-            diagnostics: diagnostics,
-            outputs: outputs,
-            content: null);
+        return BuildResponse(xsdResolved, xsdResolved ? "Environment is healthy." : "Environment has configuration issues.", diagnostics, outputs, null);
     }
 
     private static ToolResponse Compile(string markdown, string output, bool strict, string numberStyle, string metadataProfile = "default")
-    {
-        var arabic = string.Equals(numberStyle, "arabic", StringComparison.OrdinalIgnoreCase);
-        var requireFrontMatter = output == "xml";
-        var result = new LawMarkdownCompiler().Compile(markdown, filePath: null, new CompileOptions(strict, arabic, requireFrontMatter));
-        var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToList();
-        if (result.HasErrors || result.Document is null)
+        => SafeExecute(() =>
         {
-            return BuildResponse(false, "Compilation failed.", diagnostics, null, null);
-        }
+            var arabic = string.Equals(numberStyle, "arabic", StringComparison.OrdinalIgnoreCase);
+            var requireFrontMatter = string.Equals(output, "xml", StringComparison.OrdinalIgnoreCase) || string.Equals(output, "both", StringComparison.OrdinalIgnoreCase);
+            var result = new LawMarkdownCompiler().Compile(markdown, filePath: null, new CompileOptions(strict, arabic, requireFrontMatter));
+            var diagnostics = result.Diagnostics.Select(ToDiagnostic).ToList();
+            if (result.HasErrors || result.Document is null)
+            {
+                return BuildResponse(false, "Compilation failed.", diagnostics, null, null);
+            }
 
-        if (string.Equals(output, "lawtext", StringComparison.OrdinalIgnoreCase))
-        {
-            var frontMatter = FrontMatterParser.ParseDetailed(markdown);
-            var model = ApplyLawtextMetadataFallback(result.Document.Document, frontMatter);
-            var lawtext = new LawtextRenderer().Render(result.Document with { Document = model }, LawtextRenderOptions.Default with { ArabicNumbers = arabic });
-            var renderDiagnostics = LawtextRenderer.ValidateRenderedText(lawtext).Select(ToDiagnostic);
-            diagnostics.AddRange(renderDiagnostics);
+            if (string.Equals(output, "lawtext", StringComparison.OrdinalIgnoreCase))
+            {
+                var lawtext = RenderLawtext(markdown, result.Document, arabic, diagnostics);
+                var lawtextHasErrors = diagnostics.Any(x => x.Severity == "error");
+                return BuildResponse(!lawtextHasErrors, lawtextHasErrors ? "Lawtext generation failed." : "Lawtext generated successfully.", diagnostics, new Dictionary<string, object?> { ["lawtext"] = lawtext }, lawtext);
+            }
+
+            if (!string.Equals(output, "xml", StringComparison.OrdinalIgnoreCase) && !string.Equals(output, "both", StringComparison.OrdinalIgnoreCase))
+            {
+                diagnostics.Add(new ToolDiagnostic("error", "MCP004", "Unsupported 'to' option.", output));
+                return BuildResponse(false, "Compilation failed.", diagnostics, null, null);
+            }
+
+            var outputs = new Dictionary<string, object?>();
+            var xmlModel = ApplyMetadataProfile(result.Document.Document, metadataProfile);
+            var xml = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = arabic }).ToString();
+            outputs["xml"] = xml;
+
+            var xsdPath = ZukeXsdProvider.ResolveDefaultPath();
+            outputs["xsdPath"] = xsdPath;
+            if (File.Exists(xsdPath))
+            {
+                var xmlDocument = XDocument.Parse(xml);
+                diagnostics.AddRange(new LawXmlValidator().Validate(xmlDocument, xsdPath).Select(ToDiagnostic));
+            }
+            else
+            {
+                diagnostics.Add(new ToolDiagnostic("error", "MCP001", "XSD file was not found; XML validation was not run.", xsdPath));
+            }
+
+            if (string.Equals(output, "both", StringComparison.OrdinalIgnoreCase))
+            {
+                outputs["lawtext"] = RenderLawtext(markdown, result.Document, arabic, diagnostics);
+            }
+
             var hasErrors = diagnostics.Any(x => x.Severity == "error");
-            return BuildResponse(!hasErrors, hasErrors ? "Lawtext generation failed." : "Lawtext generated successfully.", diagnostics, new Dictionary<string, object?> { ["lawtext"] = lawtext }, lawtext);
-        }
+            var summary = hasErrors ? "XML generation failed validation." : "XML generated and validated successfully.";
+            return BuildResponse(!hasErrors, summary, diagnostics, outputs, xml);
+        });
 
-        var xmlModel = ApplyMetadataProfile(result.Document.Document, metadataProfile);
-        var xml = new LawXmlRenderer().Render(xmlModel, LawXmlRenderOptions.Default with { ArabicNumbers = arabic }).ToString();
+    private static string RenderLawtext(string markdown, CompiledLawDocument document, bool arabic, List<ToolDiagnostic> diagnostics)
+    {
+        var frontMatter = FrontMatterParser.ParseDetailed(markdown);
+        var model = ApplyLawtextMetadataFallback(document.Document, frontMatter);
+        var lawtext = new LawtextRenderer().Render(document with { Document = model }, LawtextRenderOptions.Default with { ArabicNumbers = arabic });
+        diagnostics.AddRange(LawtextRenderer.ValidateRenderedText(lawtext).Select(ToDiagnostic));
+        return lawtext;
+    }
 
-        var xsdPath = ZukeXsdProvider.ResolveDefaultPath();
-        if (File.Exists(xsdPath))
+    private static ToolResponse SafeExecute(Func<ToolResponse> action)
+    {
+        try { return action(); }
+        catch (Exception ex)
         {
-            var xmlDocument = XDocument.Parse(xml);
-            var xsdDiagnostics = new LawXmlValidator().Validate(xmlDocument, xsdPath).Select(ToDiagnostic);
-            diagnostics.AddRange(xsdDiagnostics);
+            return BuildResponse(false, "Unexpected error occurred.", [new ToolDiagnostic("error", "MCP999", ex.Message, null)], null, null);
         }
-        else
-        {
-            diagnostics.Add(new ToolDiagnostic("error", "MCP001", "XSD file was not found; XML validation was not run.", xsdPath));
-        }
-
-        var xmlHasErrors = diagnostics.Any(x => x.Severity == "error");
-        return BuildResponse(!xmlHasErrors, xmlHasErrors ? "XML generation failed validation." : "XML generated and validated successfully.", diagnostics, new Dictionary<string, object?> { ["xml"] = xml, ["xsdPath"] = xsdPath }, xml);
     }
 
     private static ToolResponse BuildResponse(bool success, string summary, IReadOnlyList<ToolDiagnostic> diagnostics, IReadOnlyDictionary<string, object?>? outputs, string? content)
@@ -125,13 +225,7 @@ public sealed class ZukeMcpTools
     private static LawDocumentModel ApplyLawtextMetadataFallback(LawDocumentModel model, FrontMatterParseResult frontMatter)
     {
         if (frontMatter.HasFrontMatter) return model;
-        return model with
-        {
-            Metadata = model.Metadata with
-            {
-                LawTitle = string.IsNullOrWhiteSpace(model.Metadata.LawTitle) ? "無題" : model.Metadata.LawTitle
-            }
-        };
+        return model with { Metadata = model.Metadata with { LawTitle = string.IsNullOrWhiteSpace(model.Metadata.LawTitle) ? "無題" : model.Metadata.LawTitle } };
     }
 
     private static LawDocumentModel ApplyMetadataProfile(LawDocumentModel model, string profile)
@@ -158,10 +252,4 @@ public sealed class ZukeMcpTools
 
 public sealed record ToolDiagnostic(string Severity, string Code, string Message, string? Location);
 
-public sealed record ToolResponse(
-    bool Success,
-    string Summary,
-    IReadOnlyList<ToolDiagnostic> Diagnostics,
-    IReadOnlyDictionary<string, object?>? Outputs,
-    string? Content,
-    bool HasErrors);
+public sealed record ToolResponse(bool Success, string Summary, IReadOnlyList<ToolDiagnostic> Diagnostics, IReadOnlyDictionary<string, object?>? Outputs, string? Content, bool HasErrors);

--- a/src/Zuke.Mcp/Zuke.Mcp.csproj
+++ b/src/Zuke.Mcp/Zuke.Mcp.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>zuke-mcp</ToolCommandName>
     <PackageId>Zuke.Mcp</PackageId>
-    <Version>0.1.0-preview.4</Version>
+    <Version>0.1.0-preview.5</Version>
     <Authors>Takashi U</Authors>
     <Company>Takashi-U</Company>
     <Description>Zuke MCP server for lawtext/XML compilation and validation.</Description>


### PR DESCRIPTION
### Motivation
- Expose CLI capabilities (`import`, `audit`, `diff`, `validate_xml`) as MCP tools usable by AI apps while keeping the MCP surface safe for untrusted callers. 
- Ensure all MCP tools operate on string input / string output only and avoid adding any file I/O, process execution, Git or network actions. 
- Keep existing MCP behavior and compatibility for `zuke.compile_*`, `zuke_lawtext`, and `zuke_doctor` while adding structured diagnostics for unsupported modes and unexpected errors.

### Description
- Added MCP tools in `Zuke.Mcp`: `zuke_import`, `zuke_audit`, `zuke_diff`, and `zuke_validate_xml`, implemented using `Zuke.Core` services (`LawtextImportService`, `LawtextAuditService`, `LawMarkdownCompiler`/`LawtextRenderer`/`LawtextNormalizer`/`LawtextDiffService`, and `LawXmlValidator`) and returning responses in the existing `ToolResponse`/`ToolDiagnostic` format. 
- Extended `zuke_convert` to accept `to=xml|lawtext|both` and retained backward-compatible endpoints `zuke.compile_xml`, `zuke.compile_lawtext`, and `zuke_lawtext`. 
- Implemented structured diagnostics `MCP004` (unsupported option/mode), `MCP005` (XSD cannot be resolved), and `MCP999` (unexpected exception) and return diagnostics in `outputs`/`diagnostics` instead of writing files or printing to stdout. 
- Updated `README.Mcp.md` and `docs/mcp-mvp.md` to document new tools, emphasize string I/O-only behavior and `stdio` JSON-RPC preservation, and bumped `Zuke.Mcp` package `Version` to `0.1.0-preview.5` in `src/Zuke.Mcp/Zuke.Mcp.csproj`.

### Testing
- Ran `dotnet restore ./zuke.sln` which completed successfully. 
- Ran `dotnet build ./zuke.sln -c Release` which succeeded with no errors. 
- Ran `dotnet test ./zuke.sln -c Release` and all tests passed (`192 passed`). 
- Ran `dotnet pack ./src/Zuke.Mcp/Zuke.Mcp.csproj -c Release -o ./nupkg` which produced `Zuke.Mcp.0.1.0-preview.5.nupkg` successfully.

Remaining unsupported scope
- `zuke_diff` currently supports only `view=unified`, and `view=html`/`view=terminal` return `MCP004` for now.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62314a1f88328809de076783b3d15)